### PR TITLE
allow missing package.json

### DIFF
--- a/__tests__/api/AutoBundler.test.ts
+++ b/__tests__/api/AutoBundler.test.ts
@@ -171,4 +171,19 @@ describe("AutoBundler01", () => {
         // Check the output as JSON
         expect(JSON.stringify(ab.getBundle().getManifest())).toMatch("{\"manifest\":{\"xmlns\":\"http://www.ibm.com/xmlns/prod/cics/bundle\",\"bundleVersion\":1,\"bundleRelease\":0}}");
     });
+    it("should cope with an empty directory and generate a NODEJSAPP", () => {
+
+        let parms: IHandlerParameters;
+        parms = DEFAULT_PARAMTERS;
+        parms.arguments.port = 500;
+        parms.arguments.nodejsapp = "wibble";
+        parms.arguments.startscript = "__tests__/__resources__/EmptyBundle02/META-INF";
+
+        // Create a Bundle
+        const ab = new AutoBundler("__tests__/__resources__/EmptyBundle02", parms);
+
+        // Check the output as JSON
+// tslint:disable-next-line: max-line-length
+        expect(JSON.stringify(ab.getBundle().getManifest())).toMatch("{\"manifest\":{\"xmlns\":\"http://www.ibm.com/xmlns/prod/cics/bundle\",\"bundleVersion\":1,\"bundleRelease\":0,\"define\":[{\"name\":\"wibble\",\"type\":\"http://www.ibm.com/xmlns/prod/cics/bundle/NODEJSAPP\",\"path\":\"nodejsapps/wibble.nodejsapp\"}]}}");
+    });
 });

--- a/__tests__/api/AutoBundler.test.ts
+++ b/__tests__/api/AutoBundler.test.ts
@@ -82,7 +82,7 @@ describe("AutoBundler01", () => {
 
         let parms: IHandlerParameters;
         parms = JSON.parse(JSON.stringify(DEFAULT_PARAMTERS));
-        parms.arguments.version = "3.4.5";
+        parms.arguments.bundleversion = "3.4.5";
 
         // Create a Bundle
         const ab = new AutoBundler("__tests__/__resources__/ExampleBundle03", parms);

--- a/__tests__/api/__snapshots__/AutoBundler.test.ts.snap
+++ b/__tests__/api/__snapshots__/AutoBundler.test.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AutoBundler01 should cope with an empty directory and generate a NODEJSAPP 1`] = `"NODEJSAPP \\"wibble\\" defined for startscript \\"__tests__/__resources__/EmptyBundle02/META-INF\\""`;

--- a/src/api/AutoBundler.ts
+++ b/src/api/AutoBundler.ts
@@ -162,8 +162,8 @@ export class AutoBundler {
     if (args.bundleid !== undefined) {
       this.validateBundleId(args.bundleid);
     }
-    if (args.version !== undefined) {
-      this.validateBundleVer(args.version);
+    if (args.bundleversion !== undefined) {
+      this.validateBundleVer(args.bundleversion);
     }
     if (args.nodejsapp !== undefined) {
       this.validateNodejsapp(args.nodejsapp);

--- a/src/api/AutoBundler.ts
+++ b/src/api/AutoBundler.ts
@@ -81,6 +81,22 @@ export class AutoBundler {
     if (this.fs.existsSync(this.packageJsonFile)) {
       this.processPackageJson(params);
     }
+    else {
+      // If we get here then we've not found a package.json file. it remains possible
+      // that sufficient command line parameters have been set to allow a NODEJSAPP
+      // to be created. If so, process them.
+      if (this.startscriptOverride !== undefined ||
+          this.nodejsappOverride   !== undefined ||
+          this.portOverride        !== undefined ) {
+        this.bundle.addNodejsappDefinition(this.nodejsappOverride, this.startscriptOverride, this.portOverride);
+        try {
+          params.response.console.log('NODEJSAPP "' + this.nodejsappOverride + '" defined for startscript "' + this.startscriptOverride + '"');
+        }
+        catch (error) {
+          // logging errors can be thrown in some of the mocked tests... just ignore it.
+        }
+      }
+    }
   }
 
   private processPackageJson(params: IHandlerParameters) {


### PR DESCRIPTION
Addresses issue #3.

The support for generating NODEJSAPPs was being keyed off the presence of package.json, but it does seem reasonable to support its absence if sufficient command line parameters have been provided.