### PR TITLE
Tweaks to command-line help, readme and contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,8 @@ The contribution guidelines in this document pertain to contributing to this zow
 
 This project welcomes all contributions. 
 - If you find a bug or would like to suggest an improvement, please raise an issue.
-- If you'd like to contribute a bug fix or small enhancement, please fork the repo and make a pull request.
-- If you'd like to contribute a new feature, please raise an issue describing your proposal so we can discuss it first.
+- If you would like to contribute a bug fix or small enhancement, please fork the repo and make a pull request.
+- If you would like to contribute a new feature, please raise an issue describing your proposal so we can discuss it first.
 
 ## Developing Zowe CLI plugins
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,13 @@
 # Contribution Guidelines
 The contribution guidelines in this document pertain to contributing to this zowe-cli-cics-deploy-plugin repository.
 
+This project welcomes all contributions. 
+- If you find a bug or would like to suggest an improvement, please raise an issue.
+- If you'd like to contribute a bug fix or small enhancement, please fork the repo and make a pull request.
+- If you'd like to contribute a new feature, please raise an issue describing your proposal so we can discuss it first.
+
+## Developing Zowe CLI plugins
+
 For guidelines on developing Zowe CLI plug-ins see the [Zowe CLI GitHub repository](https://github.com/zowe/zowe-cli). The following information is critical to working with the code, running/writing/maintaining automated tests, developing consistent syntax and ensuring that the plug-in integrates with Zowe CLI properly:
 
 | For more information about ... | See: |

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # zowe-cli-cics-deploy-plugin
-This project aims to create a plugin for Zowe CLI https://github.com/zowe/zowe-cli.  The plugin will provide the capability to deploy applications developed on a workstation to IBM CICS, as CICS bundles. Initially it will support deploying Node.js applications.  It aims to provide an experience similar to deploying to a cloud platform when deploying to CICS.  It will also provide low-level commands for performing individual pieces of the deployment process that could be used as part of a CI/CD pipeline.
+This project aims to create a plugin for [Zowe CLI](https://github.com/zowe/zowe-cli) to deploy applications developed on a workstation to IBM CICS Transaction Server for z/OS (CICS),  Initially it will support deploying Node.js applications.  It aims to provide an experience similar to deploying to a cloud platform when deploying to CICS.  It will also provide low-level commands for performing individual steps of the deployment process that could be used as part of a CI/CD pipeline.
 
 ## Status
-It is currently a work in progress at a fairly early stage. If you would like to try it out, you need to build the plugin from source as described [here](docs/tutorials/Setup.md). 
+It is currently a work in progress at a fairly early stage. If you would like to try it out, you need to build the plugin from source as described in [setup](docs/tutorials/Setup.md). 
 
 ## Contributing
 Contributions are welcome, see our [contribution guidelines](CONTRIBUTING.md).  
-## 
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # zowe-cli-cics-deploy-plugin
-This repository contains the cics-deploy plug-in for Zowe. Use this project for creating CICS Bundle resources from a Node.js project directory. 
+This project aims to create a plugin for Zowe CLI https://github.com/zowe/zowe-cli.  The plugin will provide the capability to deploy applications developed on a workstation to IBM CICS, as CICS bundles. Initially it will support deploying Node.js applications.  It aims to provide an experience similar to deploying to a cloud platform when deploying to CICS.  It will also provide low-level commands for performing individual pieces of the deployment process that could be used as part of a CI/CD pipeline.
 
-## Generation of CICS Bundles
-A CICS Bundle resource defines one or more resources that can be installed into a CICS region. This project is derived from the Zowe CLI Sample Plug-in project, it adds the ability to generate Bundle meta-data in the working directory.
+## Status
+It's currently a work in progress at a fairly early stage. If you'd like to try it out, at the moment you'll need to build the plugin from source as described [here](docs/tutorials/Setup.md). 
+
+## Contributing
+Contributions are welcom, see our [contribution guidelines](CONTRIBUTING.md).  
+## 

--- a/README.md
+++ b/README.md
@@ -5,5 +5,5 @@ This project aims to create a plugin for Zowe CLI https://github.com/zowe/zowe-c
 It's currently a work in progress at a fairly early stage. If you'd like to try it out, at the moment you'll need to build the plugin from source as described [here](docs/tutorials/Setup.md). 
 
 ## Contributing
-Contributions are welcom, see our [contribution guidelines](CONTRIBUTING.md).  
+Contributions are welcome, see our [contribution guidelines](CONTRIBUTING.md).  
 ## 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 This project aims to create a plugin for Zowe CLI https://github.com/zowe/zowe-cli.  The plugin will provide the capability to deploy applications developed on a workstation to IBM CICS, as CICS bundles. Initially it will support deploying Node.js applications.  It aims to provide an experience similar to deploying to a cloud platform when deploying to CICS.  It will also provide low-level commands for performing individual pieces of the deployment process that could be used as part of a CI/CD pipeline.
 
 ## Status
-It's currently a work in progress at a fairly early stage. If you'd like to try it out, at the moment you'll need to build the plugin from source as described [here](docs/tutorials/Setup.md). 
+It is currently a work in progress at a fairly early stage. If you would like to try it out, you need to build the plugin from source as described [here](docs/tutorials/Setup.md). 
 
 ## Contributing
 Contributions are welcome, see our [contribution guidelines](CONTRIBUTING.md).  

--- a/__tests__/cli/generate/__snapshots__/Generate.definition.test.ts.snap
+++ b/__tests__/cli/generate/__snapshots__/Generate.definition.test.ts.snap
@@ -21,8 +21,9 @@ import { BundleDefinition } from \\"./bundle/Bundle.definition\\";
 const GenerateDefinition: ICommandDefinition = {
     name: \\"generate\\",
     aliases: [\\"g\\", \\"gen\\"],
-    summary: \\"Transform the working directory into a CICS Bundle\\",
-    description: \\"Generate a CICS Bundle and associated meta-data files in the current working directory.\\",
+    summary: \\"Transform the working directory into a CICS bundle\\",
+    description: \\"Generate a CICS bundle and associated metadata files in the current working directory. \\" +
+                 \\"This allows the application in the current working directory to be deployed to CICS.\\",
     type: \\"group\\",
     children: [BundleDefinition]
 };

--- a/__tests__/cli/generate/bundle/__snapshots__/Bundle.definition.test.ts.snap
+++ b/__tests__/cli/generate/bundle/__snapshots__/Bundle.definition.test.ts.snap
@@ -26,13 +26,28 @@ import { PortOption } from \\"./options/Port.option\\";
 export const BundleDefinition: ICommandDefinition = {
     name: \\"bundle\\",
     aliases: [\\"b\\", \\"bun\\", \\"bund\\"],
-    summary: \\"Generates a Bundle\\",
-    description: \\"CICS Bundle meta-data is generated within the working directory. \\" +
+    summary: \\"Generate a CICS bundle\\",
+    description: \\"Generate a CICS bundle in the working directory. \\" +
                  \\"The associated data is constructed from a combination of the \\" +
-                 \\"input options and the contents of package.json.\\",
+                 \\"command-line options and the contents of package.json. If package.json exists, \\" +
+                 \\"no options are required, but if it does not exist both --startscript and --nodejsapp are required.\\",
     type: \\"command\\",
     handler: __dirname + \\"/Bundle.handler\\",
-    options: [ BundleidOption, BundleversionOption, NodejsappOption, StartscriptOption, PortOption ]
+    options: [ BundleidOption, BundleversionOption, NodejsappOption, StartscriptOption, PortOption ],
+    examples: [
+        {
+            description: \\"Generate a CICS bundle in the working directory, taking information from package.json\\",
+            options: \`\`
+        },
+        {
+            description: \\"Generate a CICS bundle in the working directory, based on package.json but using a bundle ID of \\\\\\"mybundle\\\\\\"\\",
+            options: \`--bundleid mybundle\`
+        },
+        {
+            description: \\"Generate a CICS bundle in the working directory in which there is no package.json\\",
+            options: \`--bundleid mybundle --nodejsapp myapp --startscript server.js\`
+        }
+    ]
 };
 "
 `;

--- a/__tests__/imperative.test.ts
+++ b/__tests__/imperative.test.ts
@@ -18,9 +18,9 @@ describe("imperative config", () => {
         const config = require("../src/imperative");
         expect(config.name).toBe("cics-deploy");
         expect(config.pluginHealthCheck).toContain("healthCheck.handler");
-        expect(config.pluginSummary).toBe("Generate and deploy IBM CICS Bundle resources");
+        expect(config.pluginSummary).toBe("Generate and deploy IBM CICS bundle resources");
         expect(config.productDisplayName).toBe("Zowe cics-deploy plug-in");
-        expect(config.rootCommandDescription).toContain("CICS Bundle deployment plugin.");
+        expect(config.rootCommandDescription).toContain("CICS bundle deployment plugin.");
     });
 
 });

--- a/docs/tutorials/Setup.md
+++ b/docs/tutorials/Setup.md
@@ -1,5 +1,5 @@
 # Setting up your development environment
-Before you follow the development tutorials for installing, extending, and creating a Zowe CLI plug-in, follow these steps to set up your environment.
+Before you can develop for the cics-deploy plugin, follow these steps to set up your environment.
 
 ## Prequisites
 [Install Zowe CLI](https://zowe.github.io/docs-site/user-guide/cli-installcli.html#methods-to-install-zowe-cli).

--- a/src/cli/generate/Generate.definition.ts
+++ b/src/cli/generate/Generate.definition.ts
@@ -18,8 +18,9 @@ import { BundleDefinition } from "./bundle/Bundle.definition";
 const GenerateDefinition: ICommandDefinition = {
     name: "generate",
     aliases: ["g", "gen"],
-    summary: "Transform the working directory into a CICS Bundle",
-    description: "Generate a CICS Bundle and associated meta-data files in the current working directory.",
+    summary: "Transform the working directory into a CICS bundle",
+    description: "Generate a CICS bundle and associated metadata files in the current working directory. " +
+                 "This allows the application in the current working directory to be deployed to CICS.",
     type: "group",
     children: [BundleDefinition]
 };

--- a/src/cli/generate/bundle/Bundle.definition.ts
+++ b/src/cli/generate/bundle/Bundle.definition.ts
@@ -23,8 +23,8 @@ import { PortOption } from "./options/Port.option";
 export const BundleDefinition: ICommandDefinition = {
     name: "bundle",
     aliases: ["b", "bun", "bund"],
-    summary: "Generates a bundle",
-    description: "Generate CICS bundle within the working directory. " +
+    summary: "Generate a CICS bundle",
+    description: "Generate a CICS bundle in the working directory. " +
                  "The associated data is constructed from a combination of the " +
                  "command-line options and the contents of package.json. If package.json exists, " +
                  "no options are required, but if it does not exist both --startscript and --nodejsapp are required.",

--- a/src/cli/generate/bundle/Bundle.definition.ts
+++ b/src/cli/generate/bundle/Bundle.definition.ts
@@ -41,7 +41,7 @@ export const BundleDefinition: ICommandDefinition = {
             options: `--bundleid mybundle`
         },
         {
-            description: "Generate a CICS bundle in the working directory, where the is no package.json",
+            description: "Generate a CICS bundle in the working directory in which there is no package.json",
             options: `--bundleid mybundle --nodejsapp myapp --startscript server.js`
         }
     ]

--- a/src/cli/generate/bundle/Bundle.definition.ts
+++ b/src/cli/generate/bundle/Bundle.definition.ts
@@ -23,11 +23,26 @@ import { PortOption } from "./options/Port.option";
 export const BundleDefinition: ICommandDefinition = {
     name: "bundle",
     aliases: ["b", "bun", "bund"],
-    summary: "Generates a Bundle",
-    description: "CICS Bundle meta-data is generated within the working directory. " +
+    summary: "Generates a bundle",
+    description: "Generate CICS bundle within the working directory. " +
                  "The associated data is constructed from a combination of the " +
-                 "input options and the contents of package.json.",
+                 "command-line options and the contents of package.json. If package.json exists, " +
+                 "no options are required, but if it does not exist both --startscript and --nodejsapp are required.",
     type: "command",
     handler: __dirname + "/Bundle.handler",
-    options: [ BundleidOption, BundleversionOption, NodejsappOption, StartscriptOption, PortOption ]
+    options: [ BundleidOption, BundleversionOption, NodejsappOption, StartscriptOption, PortOption ],
+    examples: [
+        {
+            description: "Generate a CICS bundle in the working directory, taking information from package.json",
+            options: ``
+        },
+        {
+            description: "Generate a CICS bundle in the working directory, based on package.json but using a bundle ID of \"mybundle\"",
+            options: `--bundleid mybundle`
+        },
+        {
+            description: "Generate a CICS bundle in the working directory, where the is no package.json",
+            options: `--bundleid mybundle --nodejsapp myapp --startscript server.js`
+        }
+    ]
 };

--- a/src/cli/generate/bundle/options/Bundleid.option.ts
+++ b/src/cli/generate/bundle/options/Bundleid.option.ts
@@ -19,7 +19,7 @@ export const BundleidOption: ICommandOptionDefinition = {
     name: "bundleid",
     aliases: ["b", "id", "bid"],
     type: "string",
-    description: "Up to 64 character identity for the CICS Bundle. If no value is " +
+    description: "The ID for the generated CICS bundle, up to 64 characters. If no value is " +
                  "specified then a default value is created from the 'name' property " +
                  "in the package.json file in the current working directory."
 };

--- a/src/cli/generate/bundle/options/Bundleid.option.ts
+++ b/src/cli/generate/bundle/options/Bundleid.option.ts
@@ -21,6 +21,8 @@ export const BundleidOption: ICommandOptionDefinition = {
     type: "string",
     description: "The ID for the generated CICS bundle, up to 64 characters. If no value is " +
                  "specified then a default value is created from the 'name' property " +
-                 "in the package.json file in the current working directory."
+                 "in the package.json file in the current working directory." +
+                 "If the value is too long it will be truncated. If it contains characters " +
+                 "not supported by CICS, each one will be replaced by an X."
 };
 

--- a/src/cli/generate/bundle/options/Nodejsapp.option.ts
+++ b/src/cli/generate/bundle/options/Nodejsapp.option.ts
@@ -19,8 +19,8 @@ export const NodejsappOption: ICommandOptionDefinition = {
     name: "nodejsapp",
     aliases: ["n", "nj", "nja"],
     type: "string",
-    description: "Up to 32 character identity for the CICS NODEJSAPP resource. If no value is " +
-                 "specified then a default value is created from the value of the " +
-                 "bundleid attribute."
+    description: "The ID of the generated CICS NODEJSAPP resource, up to 32 characters.  If no value is " +
+                 "specified then a default value is created from the " +
+                 "'name' property in package.json, or the bundleid option if specified. "
 };
 

--- a/src/cli/generate/bundle/options/Nodejsapp.option.ts
+++ b/src/cli/generate/bundle/options/Nodejsapp.option.ts
@@ -21,6 +21,9 @@ export const NodejsappOption: ICommandOptionDefinition = {
     type: "string",
     description: "The ID of the generated CICS NODEJSAPP resource, up to 32 characters.  If no value is " +
                  "specified then a default value is created from the " +
-                 "'name' property in package.json, or the bundleid option if specified. "
+                 "'name' property in package.json, or the bundleid option if specified. " +
+                 "If the value is too long it will be truncated. If it contains characters " +
+                 "not supported by CICS, each one will be replaced by an X."
+
 };
 

--- a/src/cli/generate/bundle/options/Startscript.option.ts
+++ b/src/cli/generate/bundle/options/Startscript.option.ts
@@ -20,7 +20,7 @@ export const StartscriptOption: ICommandOptionDefinition = {
     aliases: ["s", "ss"],
     type: "string",
     description: "Up to 255 character path to the Node.js start script that should run when " +
-                 "the associated Bundle is Enabled in CICS. If a value is not " +
+                 "the associated bundle is enabled in CICS. If a value is not " +
                  "specified then a default value is created from either the 'scripts.start' property " +
                  "of the package.json file in the current working directory, or from the 'main' property."
 };

--- a/src/imperative.ts
+++ b/src/imperative.ts
@@ -15,9 +15,9 @@ import {IImperativeConfig} from "@brightside/imperative";
 const config: IImperativeConfig = {
     commandModuleGlobs: ["**/cli/*/*.definition!(.d).*s"],
     pluginHealthCheck: __dirname + "/healthCheck.handler",
-    pluginSummary: "Generate and deploy IBM CICS Bundle resources",
+    pluginSummary: "Generate and deploy IBM CICS bundle resources",
     pluginAliases: ["cdep"],
-    rootCommandDescription: "CICS Bundle deployment plugin.",
+    rootCommandDescription: "CICS bundle deployment plugin.",
     productDisplayName: "Zowe cics-deploy plug-in",
     name: "cics-deploy"
 };


### PR DESCRIPTION
A few suggested tweaks to the command line help, including some examples in the style of core Zowe CLI.

Also I've added a bit of extra info the README just in case anyone comes looking in the near future. We'll need to add more info in here about how to actually use the tool over the next few weeks. 