### PR TITLE
Make sure get we get rc=1 for errors

### DIFF
--- a/__tests__/api/AutoBundler.test.ts
+++ b/__tests__/api/AutoBundler.test.ts
@@ -12,7 +12,7 @@
 import { AutoBundler } from "../../src/api/AutoBundler";
 import { IHandlerParameters } from "@brightside/imperative";
 import * as BundleDefinition from "../../src/cli/generate/bundle/Bundle.definition";
-import * as BundleHandler from "../../src/cli/generate/bundle/Bundle.handler";
+import * as fse from "fs-extra";
 
 
 const DEFAULT_PARAMTERS: IHandlerParameters = {
@@ -53,6 +53,12 @@ const DEFAULT_PARAMTERS: IHandlerParameters = {
 };
 
 describe("AutoBundler01", () => {
+
+    beforeAll(() => {
+        // Git does not commit empty dirs, so make they exist
+        fse.ensureDir("__tests__/__resources__/EmptyBundle01");
+    });
+
     it("should read an existing bundle", () => {
 
         let parms: IHandlerParameters;
@@ -177,7 +183,7 @@ describe("AutoBundler01", () => {
         parms = JSON.parse(JSON.stringify(DEFAULT_PARAMTERS));
         parms.arguments.port = 500;
         parms.arguments.nodejsapp = "wibble";
-        parms.arguments.startscript = "__tests__/__resources__/EmptyBundle02/META-INF";
+        parms.arguments.startscript = "__tests__/__resources__/EmptyBundle02/script.js";
 
         // Create a Bundle
         const ab = new AutoBundler("__tests__/__resources__/EmptyBundle02", parms);

--- a/__tests__/cli/generate/bundle/Bundle.handler.test.ts
+++ b/__tests__/cli/generate/bundle/Bundle.handler.test.ts
@@ -11,7 +11,7 @@
 */
 
 import {CheckStatus, ZosmfSession} from "@brightside/core";
-import {IHandlerParameters, Imperative} from "@brightside/imperative";
+import {IHandlerParameters, Imperative, ImperativeError} from "@brightside/imperative";
 import * as BundleDefinition from "../../../../src/cli/generate/bundle/Bundle.definition";
 import * as BundleHandler from "../../../../src/cli/generate/bundle/Bundle.handler";
 import * as fs from "fs";
@@ -115,14 +115,14 @@ describe("bundle Handler", () => {
         process.chdir(currentDir);
         expect(error).toBeUndefined();
     });
-    it("should tolerate exceptions being thrown", async () => {
+    it("should wrap exceptions in ImperativeError", async () => {
         DEFAULT_PARAMTERS.arguments.nosave = "true";
         DEFAULT_PARAMTERS.arguments.startscript = "wibble";
 
         const currentDir = process.cwd();
         process.chdir("__tests__/__resources__/ExampleBundle04");
 
-        let error;
+        let error: Error;
         try {
           const handler = new BundleHandler.default();
           // The handler should succeed
@@ -130,9 +130,9 @@ describe("bundle Handler", () => {
           await handler.process(params);
         } catch (e) {
             error = e;
-            Imperative.console.error(`Error experienced: ${e.message}`);
         }
         process.chdir(currentDir);
-        expect(error).toBeUndefined();
+        expect(error).toBeDefined();
+        expect(error).toBeInstanceOf(ImperativeError);
     });
 });

--- a/src/cli/generate/bundle/Bundle.handler.ts
+++ b/src/cli/generate/bundle/Bundle.handler.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { ICommandHandler, IHandlerParameters } from "@brightside/imperative";
+import { ICommandHandler, IHandlerParameters, ImperativeError } from "@brightside/imperative";
 import { AutoBundler } from "../../../api/AutoBundler";
 
 /**
@@ -44,9 +44,10 @@ export default class BundleHandler implements ICommandHandler {
             params.response.console.log('CICS Bundle "' + autobundler.getBundle().getId() + '" generated');
           }
         } catch (except) {
-            params.response.console.error("A failure occurred during CICS Bundle generation.\n" +
-                "Reason = " + except.message
-            );
+            const message = "A failure occurred during CICS Bundle generation.\n" +
+                "Reason = " + except.message;
+
+            throw new ImperativeError({msg: message, causeErrors: except});
         }
     }
 }


### PR DESCRIPTION
Throwing an ImperativeError from the handler causes imperative to set the return code to 1, without the unpleasant extra diagnostics emitted if you throw a regular Error.

I also fixed up a unit test I was having problems with as git doesn't check in empty directories. 