### PR TITLE
submitjobs status on errors

### DIFF
--- a/__tests__/api/BundleDeploy/__snapshots__/BundleDeployer.test.ts.snap
+++ b/__tests__/api/BundleDeploy/__snapshots__/BundleDeployer.test.ts.snap
@@ -16,7 +16,7 @@ exports[`BundleDeployer01 should complain if status can't be determined 1`] = `"
 
 exports[`BundleDeployer01 should complain if status can't be determined 2`] = `"DFHDPLOY command completed, but status cannot be determined."`;
 
-exports[`BundleDeployer01 should complain of SYSTSPRT not found 1`] = `"SYSTSPRT output from DFHDPLOY not found."`;
+exports[`BundleDeployer01 should complain of SYSTSPRT not found 1`] = `"SYSTSPRT output from DFHDPLOY not found. Most recent status update: ''."`;
 
 exports[`BundleDeployer01 should complain with missing zOSMF profile for deploy 1`] = `"Expect Error: Required parameter 'hostname' must be defined"`;
 
@@ -220,7 +220,7 @@ UNDEPLOY BUNDLE(12345678)
 "
 `;
 
-exports[`BundleDeployer01 should handle failure during submitjobs processing 1`] = `"Failure occurred submitting DFHDPLOY JCL: Cannot read property 'hostname' of undefined"`;
+exports[`BundleDeployer01 should handle failure during submitjobs processing 1`] = `"Failure occurred submitting DFHDPLOY JCL: 'Cannot read property 'hostname' of undefined'. Most recent status update: ''."`;
 
 exports[`BundleDeployer01 should support long bundledir 1`] = `"DFHRL2037I"`;
 
@@ -250,7 +250,7 @@ DEPLOY BUNDLE(12345678)
 
 exports[`BundleDeployer01 should tolerate empty output from DFHDPLOY 1`] = `"undefined"`;
 
-exports[`BundleDeployer01 should tolerate empty output from DFHDPLOY 2`] = `"DFHDPLOY did not generate any output."`;
+exports[`BundleDeployer01 should tolerate empty output from DFHDPLOY 2`] = `"DFHDPLOY did not generate any output. Most recent status update: ''."`;
 
 exports[`BundleDeployer01 should undeploy successfully 1`] = `"DFHRL2037I"`;
 

--- a/__tests__/cli/deploy/bundle/DeployBundle.handler.test.ts
+++ b/__tests__/cli/deploy/bundle/DeployBundle.handler.test.ts
@@ -374,6 +374,9 @@ describe("bundle Handler", () => {
     it("should complain if jobcard omits JOB ", async () => {
         await testJobcardError("//wibble boj", "--jobcard parameter does not have JOB keyword after the jobname. Expected 'JOB' but found 'boj'");
     });
+    it("should complain if jobcard omits JOB 2", async () => {
+        await testJobcardError("//wibble", "--jobcard parameter does not have JOB keyword after the jobname.");
+    });
     it("should complain if zosmf profile not found", async () => {
 
         const params = Object.assign({}, ...[DEFAULT_PARAMETERS]);

--- a/src/api/BundleDeploy/ParmValidator.ts
+++ b/src/api/BundleDeploy/ParmValidator.ts
@@ -302,6 +302,11 @@ export class ParmValidator {
       throw new Error("--jobcard parameter does not start with a suitable jobname: '" + jobname + " '");
     }
 
+    // Check that there is a second word
+    if (firstPartParts.length < 2) {
+      throw new Error("--jobcard parameter does not have JOB keyword after the jobname.");
+    }
+
     // check the second word is 'JOB'
     const jobkeyword = firstPartParts[1].trim();
     if (jobkeyword !== "JOB") {


### PR DESCRIPTION
This commit will improve diagnostics following a submitJobs failure.

E.g.:

Command Error:
A failure occurred during CICS bundle deployment.
 Reason = SYSTSPRT output from DFHDPLOY not found. Most recent status update: '**Retrieving spool content for JOB95498, JCL ERROR**'.

It'll usually result in the Job name appearing within the error message that's issued. 