### PR TITLE
Progress bar for Deploy/Undeploy

### DIFF
--- a/__tests__/api/BundleDeploy/__snapshots__/BundleDeployer.test.ts.snap
+++ b/__tests__/api/BundleDeploy/__snapshots__/BundleDeployer.test.ts.snap
@@ -16,7 +16,7 @@ exports[`BundleDeployer01 should complain if status can't be determined 1`] = `"
 
 exports[`BundleDeployer01 should complain if status can't be determined 2`] = `"DFHDPLOY command completed, but status cannot be determined."`;
 
-exports[`BundleDeployer01 should complain of SYSTSPRT not found 1`] = `"SYSTSPRT output from DFHDPLOY not found. Most recent status update: ''."`;
+exports[`BundleDeployer01 should complain of SYSTSPRT not found 1`] = `"SYSTSPRT output from DFHDPLOY not found. Most recent status update: 'Submitting DFHDPLOY JCL'."`;
 
 exports[`BundleDeployer01 should complain with missing zOSMF profile for deploy 1`] = `"Expect Error: Required parameter 'hostname' must be defined"`;
 
@@ -220,7 +220,7 @@ UNDEPLOY BUNDLE(12345678)
 "
 `;
 
-exports[`BundleDeployer01 should handle failure during submitjobs processing 1`] = `"Failure occurred submitting DFHDPLOY JCL: 'Cannot read property 'hostname' of undefined'. Most recent status update: ''."`;
+exports[`BundleDeployer01 should handle failure during submitjobs processing 1`] = `"Failure occurred submitting DFHDPLOY JCL: 'Cannot read property 'hostname' of undefined'. Most recent status update: 'Submitting DFHDPLOY JCL'."`;
 
 exports[`BundleDeployer01 should support long bundledir 1`] = `"DFHRL2037I"`;
 
@@ -250,7 +250,7 @@ DEPLOY BUNDLE(12345678)
 
 exports[`BundleDeployer01 should tolerate empty output from DFHDPLOY 1`] = `"undefined"`;
 
-exports[`BundleDeployer01 should tolerate empty output from DFHDPLOY 2`] = `"DFHDPLOY did not generate any output. Most recent status update: ''."`;
+exports[`BundleDeployer01 should tolerate empty output from DFHDPLOY 2`] = `"DFHDPLOY did not generate any output. Most recent status update: 'Submitting DFHDPLOY JCL'."`;
 
 exports[`BundleDeployer01 should undeploy successfully 1`] = `"DFHRL2037I"`;
 

--- a/src/api/BundleDeploy/BundleDeployer.ts
+++ b/src/api/BundleDeploy/BundleDeployer.ts
@@ -167,7 +167,7 @@ export class BundleDeployer {
   }
 
 
-  private async createZosMFSession(): Promise<AbstractSession> {
+  private async createZosMFSession(): Promise<any> {
     // Create a zosMF session
     const zosmfProfile = this.params.profiles.get("zosmf");
 
@@ -177,7 +177,7 @@ export class BundleDeployer {
     return ZosmfSession.createBasicZosmfSession(zosmfProfile);
   }
 
-  private async checkHLQDatasets(session: AbstractSession) {
+  private async checkHLQDatasets(session: any) {
     // Check that the CICS dataset value looks valid and can be viewed
     // Access errors will trigger an Exception
     const cicspds = this.params.arguments.cicshlq + ".SDFHLOAD";

--- a/src/api/BundleDeploy/BundleDeployer.ts
+++ b/src/api/BundleDeploy/BundleDeployer.ts
@@ -219,7 +219,7 @@ export class BundleDeployer {
     }
   }
 
-  private async submitJCL(jcl: string, session: AbstractSession): Promise<string> {
+  private async submitJCL(jcl: string, session: any): Promise<string> {
     let spoolOutput: any;
     const status: ITaskWithStatus = { percentComplete: TaskProgress.TEN_PERCENT,
                                       statusMessage: "Submitting DFHDPLOY JCL",

--- a/src/api/BundleDeploy/BundleDeployer.ts
+++ b/src/api/BundleDeploy/BundleDeployer.ts
@@ -11,7 +11,8 @@
 
 "use strict";
 
-import { IHandlerParameters, Logger, ImperativeError, Session, ITaskWithStatus, TaskStage , TaskProgress} from "@brightside/imperative";
+import { IHandlerParameters, Logger, ImperativeError, AbstractSession, ITaskWithStatus,
+         TaskStage , TaskProgress} from "@brightside/imperative";
 import { ZosmfSession, SubmitJobs, List } from "@brightside/core";
 import { ParmValidator } from "./ParmValidator";
 
@@ -166,7 +167,7 @@ export class BundleDeployer {
   }
 
 
-  private async createZosMFSession(): Promise<Session> {
+  private async createZosMFSession(): Promise<AbstractSession> {
     // Create a zosMF session
     const zosmfProfile = this.params.profiles.get("zosmf");
 
@@ -176,7 +177,7 @@ export class BundleDeployer {
     return ZosmfSession.createBasicZosmfSession(zosmfProfile);
   }
 
-  private async checkHLQDatasets(session: Session) {
+  private async checkHLQDatasets(session: AbstractSession) {
     // Check that the CICS dataset value looks valid and can be viewed
     // Access errors will trigger an Exception
     const cicspds = this.params.arguments.cicshlq + ".SDFHLOAD";
@@ -218,7 +219,7 @@ export class BundleDeployer {
     }
   }
 
-  private async submitJCL(jcl: string, session: Session): Promise<string> {
+  private async submitJCL(jcl: string, session: AbstractSession): Promise<string> {
     let spoolOutput: any;
     const status: ITaskWithStatus = { percentComplete: TaskProgress.TEN_PERCENT,
                                       statusMessage: "Submitting DFHDPLOY JCL",

--- a/src/api/BundleDeploy/BundleDeployer.ts
+++ b/src/api/BundleDeploy/BundleDeployer.ts
@@ -11,7 +11,7 @@
 
 "use strict";
 
-import { IHandlerParameters, Logger, ImperativeError, Session, ITaskWithStatus, TaskStage } from "@brightside/imperative";
+import { IHandlerParameters, Logger, ImperativeError, Session, ITaskWithStatus, TaskStage , TaskProgress} from "@brightside/imperative";
 import { ZosmfSession, SubmitJobs, List } from "@brightside/core";
 import { ParmValidator } from "./ParmValidator";
 
@@ -24,6 +24,8 @@ import { ParmValidator } from "./ParmValidator";
 export class BundleDeployer {
 
   private params: IHandlerParameters;
+  private PROGRESS_BAR_INTERVAL = 1500; // milliseconds
+  private PROGRESS_BAR_MAX = 67;
 
   /**
    * Constructor for a BundleDeployer.
@@ -203,9 +205,31 @@ export class BundleDeployer {
     }
   }
 
+  private updateProgressBar(status: ITaskWithStatus) {
+    // Increment the progress by 1%. This will refresh what the user sees
+    // on the console.
+    status.percentComplete = status.percentComplete + 1;
+
+    // Continue iterating on progress updates until we've reached the max value,
+    // or until the processing has completed.
+    if (status.percentComplete < this.PROGRESS_BAR_MAX &&
+        status.stageName === TaskStage.IN_PROGRESS) {
+      setTimeout(this.updateProgressBar.bind(this), this.PROGRESS_BAR_INTERVAL, status);
+    }
+  }
+
   private async submitJCL(jcl: string, session: Session): Promise<string> {
     let spoolOutput: any;
-    const status: ITaskWithStatus = { percentComplete: 0, statusMessage: "", stageName: TaskStage.NOT_STARTED };
+    const status: ITaskWithStatus = { percentComplete: TaskProgress.TEN_PERCENT,
+                                      statusMessage: "Submitting DFHDPLOY JCL",
+                                      stageName: TaskStage.IN_PROGRESS };
+    this.params.response.progress.startBar({task: status});
+
+    // Refresh the progress bar by 1% every second or so up to a max of 67%.
+    // SubmitJobs will initialise it to 30% and set it to 70% when it
+    // completes, we tweak it every so often until then for purely cosmetic purposes.
+    setTimeout(this.updateProgressBar.bind(this), this.PROGRESS_BAR_INTERVAL, status);
+
     try {
       spoolOutput = await SubmitJobs.submitJclString(session, jcl, {
                              jclSource: "",
@@ -214,6 +238,7 @@ export class BundleDeployer {
                            });
     }
     catch (error) {
+      status.stageName = TaskStage.FAILED;
       throw new Error("Failure occurred submitting DFHDPLOY JCL: '" + error.message +
                       "'. Most recent status update: '" + status.statusMessage + "'.");
     }
@@ -229,27 +254,38 @@ export class BundleDeployer {
         logger.debug(file.data);
 
         if (file.data === undefined || file.data.length === 0) {
+          status.stageName = TaskStage.FAILED;
           throw new Error("DFHDPLOY did not generate any output. Most recent status update: '" + status.statusMessage + "'.");
         }
 
+        // Finish the progress bar
+        status.statusMessage = "Completed DFHDPLOY";
+        this.params.response.progress.endBar();
+
         // Did DFHDPLOY fail?
         if (file.data.indexOf("DFHRL2055I") > -1) {
+          status.stageName = TaskStage.FAILED;
           throw new Error("DFHDPLOY stopped processing due to an error.");
         }
         if (file.data.indexOf("DFHRL2043I") > -1) {
+          status.stageName = TaskStage.COMPLETE;
           return "DFHDPLOY completed with warnings.";
         }
         if (file.data.indexOf("DFHRL2012I") > -1) {
+          status.stageName = TaskStage.COMPLETE;
           return "DFHDPLOY DEPLOY command successful.";
         }
         if (file.data.indexOf("DFHRL2037I") > -1) {
+          status.stageName = TaskStage.COMPLETE;
           return "DFHDPLOY UNDEPLOY command successful.";
         }
 
+        status.stageName = TaskStage.FAILED;
         throw new Error("DFHDPLOY command completed, but status cannot be determined.");
       }
     }
 
+    status.stageName = TaskStage.FAILED;
     throw new Error("SYSTSPRT output from DFHDPLOY not found. Most recent status update: '" + status.statusMessage + "'.");
   }
 }


### PR DESCRIPTION
A purely cosmetic change - it makes waiting for the JCL output a little less dull and offers some assurance that cics-deploy hasn't stalled.