### PR TITLE
support \n in jobcard

### DIFF
--- a/__tests__/api/BundleDeploy/BundleDeployer.test.ts
+++ b/__tests__/api/BundleDeploy/BundleDeployer.test.ts
@@ -19,8 +19,7 @@ import { ZosmfSession, SubmitJobs, List } from "@brightside/core";
 const DEFAULT_PARAMTERS: IHandlerParameters = {
     arguments: {
         $0: "bright",
-        _: ["zowe-cli-cics-deploy-plugin", "deploy", "bundle"],
-        jobcard: "//DFHDPLOY JOB DFHDPLOY,CLASS=A,MSGCLASS=X,TIME=NOLIMIT"
+        _: ["zowe-cli-cics-deploy-plugin", "deploy", "bundle"]
     },
     profiles: {
         get: (type: string) => {
@@ -191,6 +190,16 @@ describe("BundleDeployer01", () => {
         parms.arguments.timeout = 1500;
         await testDeployJCL(parms);
     });
+    it("should support multi-line jobcard", async () => {
+
+        let parms: IHandlerParameters;
+        parms = DEFAULT_PARAMTERS;
+        setCommonParmsForDeployTests(parms);
+        parms.arguments.resgroup = "12345678";
+        parms.arguments.jobcard = "//DFHDPLOY JOB DFHDPLOY,CLASS=A,\n" +
+                                  "//         MSGCLASS=X,TIME=NOLIMIT";
+        await testDeployJCL(parms);
+    });
     it("should support long bundledir", async () => {
 
         let parms: IHandlerParameters;
@@ -312,6 +321,7 @@ function setCommonParmsForUndeployTests(parms: IHandlerParameters) {
   parms.arguments.resgroup = undefined;
   parms.arguments.timeout = undefined;
   parms.arguments.name = "12345678";
+  parms.arguments.jobcard = "//DFHDPLOY JOB DFHDPLOY,CLASS=A,MSGCLASS=X,TIME=NOLIMIT";
 }
 
 async function testDeployJCL(parms: IHandlerParameters) {

--- a/__tests__/api/BundleDeploy/__snapshots__/BundleDeployer.test.ts.snap
+++ b/__tests__/api/BundleDeploy/__snapshots__/BundleDeployer.test.ts.snap
@@ -248,6 +248,33 @@ DEPLOY BUNDLE(12345678)
 "
 `;
 
+exports[`BundleDeployer01 should support multi-line jobcard 1`] = `"DFHRL2037I"`;
+
+exports[`BundleDeployer01 should support multi-line jobcard 2`] = `
+"//DFHDPLOY JOB DFHDPLOY,CLASS=A,
+//         MSGCLASS=X,TIME=NOLIMIT
+//DFHDPLOY EXEC PGM=DFHDPLOY,REGION=100M
+//STEPLIB  DD DISP=SHR,DSN=12345678901234567890123456789012345.SDFHLOAD
+//         DD DISP=SHR,DSN=abcde12345abcde12345abcde12345abcde.SEYUAUTH
+//SYSTSPRT DD SYSOUT=*
+//SYSIN    DD *
+*
+SET CICSPLEX(12345678);
+*
+UNDEPLOY BUNDLE(12345678)
+       SCOPE(12345678)
+       STATE(DISCARDED)
+       RESGROUP(12345678);
+*
+DEPLOY BUNDLE(12345678)
+       BUNDLEDIR(1234567890)
+       SCOPE(12345678)
+       STATE(AVAILABLE)
+       RESGROUP(12345678);
+/*
+"
+`;
+
 exports[`BundleDeployer01 should tolerate empty output from DFHDPLOY 1`] = `"undefined"`;
 
 exports[`BundleDeployer01 should tolerate empty output from DFHDPLOY 2`] = `"DFHDPLOY did not generate any output. Most recent status update: 'Submitting DFHDPLOY JCL'."`;

--- a/src/api/BundleDeploy/ParmValidator.ts
+++ b/src/api/BundleDeploy/ParmValidator.ts
@@ -281,6 +281,9 @@ export class ParmValidator {
       throw new Error("--jobcard parameter is empty");
     }
 
+    // resolve any new line escape sequences embedded in the jobcard
+    params.arguments.jobcard = params.arguments.jobcard.replace("\\n", "\n");
+
     // split the jobcard into a comma separated list
     const jobcardParts = params.arguments.jobcard.split(",");
     const firstPart = jobcardParts[0].trim();


### PR DESCRIPTION
This should resolve issue #32, it only adds support for /n in a jobcard, not for other escaped characters.