### PR TITLE
line-wrap for jobcard

### DIFF
--- a/__tests__/api/BundleDeploy/BundleDeployer.test.ts
+++ b/__tests__/api/BundleDeploy/BundleDeployer.test.ts
@@ -200,6 +200,44 @@ describe("BundleDeployer01", () => {
                                   "//         MSGCLASS=X,TIME=NOLIMIT";
         await testDeployJCL(parms);
     });
+    it("should support long line jobcard", async () => {
+
+        let parms: IHandlerParameters;
+        parms = DEFAULT_PARAMTERS;
+        setCommonParmsForDeployTests(parms);
+        parms.arguments.resgroup = "12345678";
+        parms.arguments.jobcard = "//DFHDPLOY JOB DFHDPLOY,CLASS=A,MSGCLASS=X,TIME=NOLIMIT,NOEL=ABCDEFGHIJKMNOPQRSTUVWXYZ";
+        await testDeployJCL(parms);
+    });
+    it("should support really long line jobcard", async () => {
+
+        let parms: IHandlerParameters;
+        parms = DEFAULT_PARAMTERS;
+        setCommonParmsForDeployTests(parms);
+        parms.arguments.resgroup = "12345678";
+        parms.arguments.jobcard = "//DFHDPLOY JOB DFHDPLOY,CLASS=A,MSGCLASS=X,TIME=NOLIMIT,NOEL=ABCDEFGHIJKMNOPQRSTUVWXYZ," +
+                                  "72CHARS=ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz," +
+                                  "ALPHABETIC=ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+        await testDeployJCL(parms);
+    });
+    it("should fail with overlong jobcard", async () => {
+
+        let parms: IHandlerParameters;
+        parms = DEFAULT_PARAMTERS;
+        setCommonParmsForDeployTests(parms);
+        parms.arguments.resgroup = "12345678";
+        parms.arguments.jobcard = "//DFHDPLOY JOB DFHDPLOY,CLASS=A,MSGCLASS=X,TIME=NOLIMIT,NOEL=ABCDEFGHIJKMNOPQRSTUVWXYZ," +
+                                  "ALPHABETIC=ABCDEFGHIJKLMNOPQRSTUVWXYZ," +
+                                  "73CHARS=ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1";
+        let err: Error;
+        try {
+          await testDeployJCL(parms);
+        } catch (e) {
+          err = e;
+        }
+        expect(err).toBeDefined();
+        expect(err.message).toMatchSnapshot();
+    });
     it("should support long bundledir", async () => {
 
         let parms: IHandlerParameters;

--- a/__tests__/api/BundleDeploy/__snapshots__/BundleDeployer.test.ts.snap
+++ b/__tests__/api/BundleDeploy/__snapshots__/BundleDeployer.test.ts.snap
@@ -30,6 +30,8 @@ exports[`BundleDeployer01 should deploy successfully 1`] = `"DFHRL2012I"`;
 
 exports[`BundleDeployer01 should deploy successfully 2`] = `"DFHDPLOY DEPLOY command successful."`;
 
+exports[`BundleDeployer01 should fail with overlong jobcard 1`] = `"--jobcard parameter section cannot be split into 72 character lines: '//         73CHARS=ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1'."`;
+
 exports[`BundleDeployer01 should generate deploy JCL for csdgroup 1`] = `"DFHRL2037I"`;
 
 exports[`BundleDeployer01 should generate deploy JCL for csdgroup 2`] = `
@@ -248,11 +250,67 @@ DEPLOY BUNDLE(12345678)
 "
 `;
 
+exports[`BundleDeployer01 should support long line jobcard 1`] = `"DFHRL2037I"`;
+
+exports[`BundleDeployer01 should support long line jobcard 2`] = `
+"//DFHDPLOY JOB DFHDPLOY,CLASS=A,MSGCLASS=X,TIME=NOLIMIT,
+//         NOEL=ABCDEFGHIJKMNOPQRSTUVWXYZ
+//DFHDPLOY EXEC PGM=DFHDPLOY,REGION=100M
+//STEPLIB  DD DISP=SHR,DSN=12345678901234567890123456789012345.SDFHLOAD
+//         DD DISP=SHR,DSN=abcde12345abcde12345abcde12345abcde.SEYUAUTH
+//SYSTSPRT DD SYSOUT=*
+//SYSIN    DD *
+*
+SET CICSPLEX(12345678);
+*
+UNDEPLOY BUNDLE(12345678)
+       SCOPE(12345678)
+       STATE(DISCARDED)
+       RESGROUP(12345678);
+*
+DEPLOY BUNDLE(12345678)
+       BUNDLEDIR(1234567890)
+       SCOPE(12345678)
+       STATE(AVAILABLE)
+       RESGROUP(12345678);
+/*
+"
+`;
+
 exports[`BundleDeployer01 should support multi-line jobcard 1`] = `"DFHRL2037I"`;
 
 exports[`BundleDeployer01 should support multi-line jobcard 2`] = `
 "//DFHDPLOY JOB DFHDPLOY,CLASS=A,
 //         MSGCLASS=X,TIME=NOLIMIT
+//DFHDPLOY EXEC PGM=DFHDPLOY,REGION=100M
+//STEPLIB  DD DISP=SHR,DSN=12345678901234567890123456789012345.SDFHLOAD
+//         DD DISP=SHR,DSN=abcde12345abcde12345abcde12345abcde.SEYUAUTH
+//SYSTSPRT DD SYSOUT=*
+//SYSIN    DD *
+*
+SET CICSPLEX(12345678);
+*
+UNDEPLOY BUNDLE(12345678)
+       SCOPE(12345678)
+       STATE(DISCARDED)
+       RESGROUP(12345678);
+*
+DEPLOY BUNDLE(12345678)
+       BUNDLEDIR(1234567890)
+       SCOPE(12345678)
+       STATE(AVAILABLE)
+       RESGROUP(12345678);
+/*
+"
+`;
+
+exports[`BundleDeployer01 should support really long line jobcard 1`] = `"DFHRL2037I"`;
+
+exports[`BundleDeployer01 should support really long line jobcard 2`] = `
+"//DFHDPLOY JOB DFHDPLOY,CLASS=A,MSGCLASS=X,TIME=NOLIMIT,
+//         NOEL=ABCDEFGHIJKMNOPQRSTUVWXYZ,
+//         72CHARS=ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz,
+//         ALPHABETIC=ABCDEFGHIJKLMNOPQRSTUVWXYZ
 //DFHDPLOY EXEC PGM=DFHDPLOY,REGION=100M
 //STEPLIB  DD DISP=SHR,DSN=12345678901234567890123456789012345.SDFHLOAD
 //         DD DISP=SHR,DSN=abcde12345abcde12345abcde12345abcde.SEYUAUTH


### PR DESCRIPTION
This commit implements a 72 char line-wrap for jobcards. It's not completely foolproof, one can find valid values for which the user might have to manually embed a newline in order to cope, but for most uses it should allow the jobcard to wrap automatically at a suitable comma. An error message is added for values that simply can't be held in 72 characters. This is intended to address issue #30.