### PR TITLE
Install dev version of Zowe CLI from Artifactory

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -199,10 +199,12 @@ pipeline {
             steps('Install Zowe CLI') {
                 timeout(time: 10, unit: 'MINUTES') {
                     echo "Install Zowe CLI globaly"
-                    sh("npm set registry https://registry.npmjs.org")
-                    sh("npm set @brightside:registry https://api.bintray.com/npm/ca/brightside/")
-                    sh("npm set @zowe:registry https://api.bintray.com/npm/ca/brightside/")
-                    sh("npm install -g @zowe/cli@latest")
+                    sh "rm -f .npmrc"
+                    sh 'curl -u $USERNAME:$API_KEY https://eu.artifactory.swg-devops.com/artifactory/api/npm/auth/ >> .npmrc'
+                    sh "echo registry=$TEST_NPM_REGISTRY >> .npmrc"
+                    sh "echo @brightside:registry=$TEST_NPM_REGISTRY >> .npmrc"
+                    sh "echo @zowe:registry=$TEST_NPM_REGISTRY >> .npmrc"
+                    sh("npm install -g @zowe/cli@cicsdev")
                     sh("zowe --version")
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -197,15 +197,17 @@ pipeline {
                 }
             }
             steps('Install Zowe CLI') {
-                timeout(time: 10, unit: 'MINUTES') {
-                    echo "Install Zowe CLI globaly"
-                    sh "rm -f ~/.npmrc"
-                    sh 'curl -u $USERNAME:$API_KEY https://eu.artifactory.swg-devops.com/artifactory/api/npm/auth/ >> ~/.npmrc'
-                    sh "echo registry=$TEST_NPM_REGISTRY >> ~/.npmrc"
-                    sh "echo @brightside:registry=$TEST_NPM_REGISTRY >> ~/.npmrc"
-                    sh "echo @zowe:registry=$TEST_NPM_REGISTRY >> ~/.npmrc"
-                    sh("npm install -g @zowe/cli@cicsdev")
-                    sh("zowe --version")
+                withCredentials([usernamePassword(credentialsId: ARTIFACTORY_CREDENTIALS_ID, usernameVariable: 'USERNAME', passwordVariable: 'API_KEY')]) {
+                    timeout(time: 10, unit: 'MINUTES') {
+                        echo "Install Zowe CLI globaly"
+                        sh "rm -f ~/.npmrc"
+                        sh 'curl -u $USERNAME:$API_KEY https://eu.artifactory.swg-devops.com/artifactory/api/npm/auth/ >> ~/.npmrc'
+                        sh "echo registry=$TEST_NPM_REGISTRY >> ~/.npmrc"
+                        sh "echo @brightside:registry=$TEST_NPM_REGISTRY >> ~/.npmrc"
+                        sh "echo @zowe:registry=$TEST_NPM_REGISTRY >> ~/.npmrc"
+                        sh("npm install -g @zowe/cli@cicsdev")
+                        sh("zowe --version")
+                    }
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -199,11 +199,11 @@ pipeline {
             steps('Install Zowe CLI') {
                 timeout(time: 10, unit: 'MINUTES') {
                     echo "Install Zowe CLI globaly"
-                    sh "rm -f .npmrc"
-                    sh 'curl -u $USERNAME:$API_KEY https://eu.artifactory.swg-devops.com/artifactory/api/npm/auth/ >> .npmrc'
-                    sh "echo registry=$TEST_NPM_REGISTRY >> .npmrc"
-                    sh "echo @brightside:registry=$TEST_NPM_REGISTRY >> .npmrc"
-                    sh "echo @zowe:registry=$TEST_NPM_REGISTRY >> .npmrc"
+                    sh "rm -f ~/.npmrc"
+                    sh 'curl -u $USERNAME:$API_KEY https://eu.artifactory.swg-devops.com/artifactory/api/npm/auth/ >> ~/.npmrc'
+                    sh "echo registry=$TEST_NPM_REGISTRY >> ~/.npmrc"
+                    sh "echo @brightside:registry=$TEST_NPM_REGISTRY >> ~/.npmrc"
+                    sh "echo @zowe:registry=$TEST_NPM_REGISTRY >> ~/.npmrc"
                     sh("npm install -g @zowe/cli@cicsdev")
                     sh("zowe --version")
                 }


### PR DESCRIPTION
Our push code requires our enhancements to Zowe CLI for SSH and file upload with .zosattributes. I've built a version of @zowe/ci with these enhancements and published it to our npm repo on Artifactory.  This PR installs Zowe CLI from there before running our tests.