### PR TITLE
Update console examples to be on one line

### DIFF
--- a/docs/pages/cdp/cdp-Create-Zowe-CLI-profiles.md
+++ b/docs/pages/cdp/cdp-Create-Zowe-CLI-profiles.md
@@ -18,8 +18,7 @@ This profile identifies the z/OSMF server that has access to the directory on z/
 
 For example, to create a z/OSMF profile:
 ```console
-zowe profiles create zosmf-profile myzos --host myzos.example.com --port 3000
-     --user myuserid --password mypassword --reject-unauthorized false --overwrite
+zowe profiles create zosmf-profile myzos --host myzos.example.com --port 3000 --user myuserid --password mypassword --reject-unauthorized false --overwrite
 ```
 For help on using the options:
 ```console
@@ -42,8 +41,7 @@ It is recommended that you use the same user ID and host to connect with SSH as 
 
 For example, to create an SSH profile:
 ```console
-zowe profiles create ssh-profile myzos --host myzos.example.com
-     --user myuserid --password mypassword --overwrite
+zowe profiles create ssh-profile myzos --host myzos.example.com --user myuserid --password mypassword --overwrite
 ```
 For help on using the options:
 ```console
@@ -66,9 +64,7 @@ This profile identifies the CICS environment for deployment. You need to know th
 
 For example to create a cics-deploy profile:
 ```console
-zowe profiles create cics-deploy-profile example --cicsplex PLEX1
-     --cicshlq CICSTS55.CICS720 --cpsmhlq CICSTS55.CPSM550
-     --scope TESTGRP1 --csdgroup BUNDGRP1 --overwrite
+zowe profiles create cics-deploy-profile example --cicsplex PLEX1 --cicshlq CICSTS55.CICS720 --cpsmhlq CICSTS55.CPSM550 --scope TESTGRP1 --csdgroup BUNDGRP1 --overwrite
 ```
 For help on using the options:
 ```console

--- a/docs/pages/cdp/cdp-Developer-pushing-Node.js-apps.md
+++ b/docs/pages/cdp/cdp-Developer-pushing-Node.js-apps.md
@@ -37,7 +37,9 @@ You also need an existing CICS bundle in the current working directory. For more
 
 The `cics-deploy push bundle` command pushes a bundle from the working directory to a target CICS environment. It requires the use of a z/OSMF profile and an ssh profile to do so, use of a cics-deploy profile is also encouraged (for more information on these dependencies see [Requirements for Push](#push_req)). You can request assistance on using the push command by issuing the following command:
 
-  `zowe cics-deploy push bundle --help`
+   ```console
+   zowe cics-deploy push bundle --help
+   ```
 
 If you have configured default profiles for zosmf, ssh and cics-deploy then only two further items are needed:
 
@@ -46,16 +48,21 @@ If you have configured default profiles for zosmf, ssh and cics-deploy then only
 
 For example, you might issue the following command:
 
-  `zowe cics-deploy push bundle --name EXAMPLE1 --targetdir /u/user01/myBundles`
+   ```console
+   zowe cics-deploy push bundle --name EXAMPLE1 --targetdir /u/user01/myBundles
+   ```
 
 This command causes cics-deploy to attempt to deploy a bundle from the current working directory to the target CICS environment under the name `EXAMPLE1`. If a bundle exists in the target environment with the same name, cics-deploy returns an error. You can instruct cics-deploy to overwrite the existing bundle by adding the --overwrite parameter, for example:
 
-  `zowe cics-deploy push bundle --name EXAMPLE1 --targetdir /u/user01/myBundles --overwrite`
+   ```console
+   zowe cics-deploy push bundle --name EXAMPLE1 --targetdir /u/user01/myBundles --overwrite
+   ```
 
 You can also request verbose messages from cics-deploy by adding the --verbose option, for example:
 
-  `zowe cics-deploy push bundle --name EXAMPLE1 --targetdir /u/user01/myBundles --overwrite --verbose`
-
+   ```console
+   zowe cics-deploy push bundle --name EXAMPLE1 --targetdir /u/user01/myBundles --overwrite --verbose
+   ```
 
 <a name="push_components"></a>
 ### Subcomponents of the push command
@@ -68,4 +75,3 @@ The `cics-deploy push bundle` command consists of several separate actions, each
 4. It deploys a bundle by using `zowe cics-deploy deploy bundle` (See [Deploying a CICS bundle](#deploying)).
 
 Advanced users might prefer to use these subcommands in preference to the `push` command. For example, if the target CICS regions are not CPSM-managed then you might use Zowe to generate and then upload the bundle, and your own scripts to deploy the bundle into a CICS region.
-

--- a/src/cli/generate/bundle/options/Port.option.ts
+++ b/src/cli/generate/bundle/options/Port.option.ts
@@ -19,9 +19,9 @@ export const PortOption: ICommandOptionDefinition = {
     name: "port",
     aliases: ["p"],
     type: "string",
-    description: "An optional TCP/IP port number that the Node.js application expects to use. " +
-                 "If a value is specified, it is stored within the generated NODEJSAPP's profile " +
-                 "and the associated value can be referenced programmatically by using the 'PORT' " +
-                 "environment variable."
+    description: "The TCP/IP port number the Node.js application should use for clients to connect to. " +
+                 "If a value is specified, it is set within the generated NODEJSAPP's profile. " +
+                 "The Node.js application can reference this value by accessing the PORT environment variable, " +
+                 "for example using process.env.PORT. " +
+                 "Additional environment variables can be set by manually editing the profile."
 };
-


### PR DESCRIPTION
Console examples should be on one line so they can be copied and pasted into the
terminal.