### PR TITLE
Rename parms to follow the naming convention

### DIFF
--- a/__tests__/api/BundlePush/BundlePusher.test.ts
+++ b/__tests__/api/BundlePush/BundlePusher.test.ts
@@ -415,7 +415,7 @@ describe("BundlePusher01", () => {
 
         await runPushTestWithError("__tests__/__resources__/ExampleBundle01", true,
               "A problem occurred attempting to run 'if [ \"$(ls)\" ]; then rm -r *; fi' in remote directory '/u/ThisDoesNotExist/12345678'. " +
-              "Problem is: The output from the remote command implied that an error occurred.");
+              "Problem is: The output from the remote command implied that an error occurred, return code 1.");
 
         expect(consoleText).toContain("Ssh command exit with non zero status");
         expect(zosMFSpy).toHaveBeenCalledTimes(1);
@@ -434,7 +434,7 @@ describe("BundlePusher01", () => {
 
         await runPushTestWithError("__tests__/__resources__/ExampleBundle01", true,
               "A problem occurred attempting to run 'if [ \"$(ls)\" ]; then rm -r *; fi' in remote directory '/u/ThisDoesNotExist/12345678'. " +
-              "Problem is: The output from the remote command implied that an error occurred.");
+              "Problem is: The output from the remote command implied that an error occurred, return code 127");
 
         expect(consoleText).toContain("Injected FSUM9195 error message");
         expect(zosMFSpy).toHaveBeenCalledTimes(1);
@@ -453,7 +453,7 @@ describe("BundlePusher01", () => {
 
         await runPushTestWithError("__tests__/__resources__/ExampleBundle01", true,
               "A problem occurred attempting to run 'if [ \"$(ls)\" ]; then rm -r *; fi' in remote directory '/u/ThisDoesNotExist/12345678'. " +
-              "Problem is: The output from the remote command implied that an error occurred.");
+              "Problem is: The output from the remote command implied that an error occurred, return code 1.");
 
         expect(consoleText).toContain("Injected FSUM9195 and FSUM9196 error message");
         expect(zosMFSpy).toHaveBeenCalledTimes(1);
@@ -647,7 +647,7 @@ describe("BundlePusher01", () => {
         await runPushTestWithError("__tests__/__resources__/ExampleBundle01", false,
               "A problem occurred attempting to run 'export PATH=\"$PATH:/usr/lpp/IBM/cnj/IBM/node-latest-os390-s390x/bin\" " +
               "&& npm install' in remote directory '/u/ThisDoesNotExist/12345678'. " +
-              "Problem is: The output from the remote command implied that an error occurred.");
+              "Problem is: The output from the remote command implied that an error occurred, return code 1.");
 
         expect(consoleText).toContain("Injected stdout error message");
         expect(zosMFSpy).toHaveBeenCalledTimes(1);
@@ -680,7 +680,7 @@ describe("BundlePusher01", () => {
         await runPushTestWithError("__tests__/__resources__/ExampleBundle01", false,
               "A problem occurred attempting to run 'export PATH=\"$PATH:/usr/lpp/IBM/cnj/IBM/node-latest-os390-s390x/bin\" " +
               "&& npm install' in remote directory '/u/ThisDoesNotExist/12345678'. " +
-              "Problem is: The output from the remote command implied that an error occurred.");
+              "Problem is: The output from the remote command implied that an error occurred, return code 1.");
 
         expect(consoleText).toContain("Injected FSUM7351 not found message");
         expect(zosMFSpy).toHaveBeenCalledTimes(1);
@@ -713,7 +713,7 @@ describe("BundlePusher01", () => {
         await runPushTestWithError("__tests__/__resources__/ExampleBundle01", false,
               "A problem occurred attempting to run 'export PATH=\"$PATH:/usr/lpp/IBM/cnj/IBM/node-latest-os390-s390x/bin\" " +
               "&& npm install' in remote directory '/u/ThisDoesNotExist/12345678'. " +
-              "Problem is: The output from the remote command implied that an error occurred.");
+              "Problem is: The output from the remote command implied that an error occurred, return code 1.");
 
         expect(consoleText).toContain("Injected npm ERR! Exit status 1 message");
         expect(zosMFSpy).toHaveBeenCalledTimes(1);

--- a/docs-internal/CLIReadme.md
+++ b/docs-internal/CLIReadme.md
@@ -40,7 +40,7 @@ the target group of CICS regions\.
 	* Specifies the name of the CICS BUNDLE resource (up to 8 characters) to deploy or
 undeploy.
 
-*   `--bundle-directory`  | `--bd` | `--bundledir` *(string)*
+*   `--bundle-directory`  | `--bd` | `--bundledir` | `--bundle-dir` *(string)*
 
 	* Specifies the location of the CICS bundle (up to 255 characters) on zFS.
 
@@ -283,7 +283,7 @@ If a bundle is deployed then a resource is defined in the BAS data repository;
 if a bundle is undeployed then the definition is removed. The --csd-group and
 --res-group options are mutually exclusive.
 
-*   `--target-directory`  | `--td` | `--targetdir` *(string)*
+*   `--target-directory`  | `--td` | `--targetdir` | `--target-dir` *(string)*
 
 	* Specifies the target zFS location to which CICS bundles should be uploaded (up
 to 255 characters).
@@ -365,7 +365,7 @@ datasets can be found in the target environment.
 	* Specifies the High Level Qualifier (up to 35 characters) at which the CPSM
 datasets can be found in the target environment.
 
-*   `--target-directory`  | `--td` | `--targetdir` *(string)*
+*   `--target-directory`  | `--td` | `--targetdir` | `--target-dir` *(string)*
 
 	* Specifies the target zFS location to which CICS bundles should be uploaded (up
 to 255 characters).
@@ -479,7 +479,7 @@ Push a CICS bundle from the working directory to a target CICSplex\.
 	* Specifies the name of the CICS BUNDLE resource (up to 8 characters) to deploy or
 undeploy.
 
-*   `--target-directory`  | `--td` | `--targetdir` *(string)*
+*   `--target-directory`  | `--td` | `--targetdir` | `--target-dir` *(string)*
 
 	* Specifies the target zFS location in which the CICS bundle is to be created (up
 to 255 characters)

--- a/docs-internal/CLIReadme.md
+++ b/docs-internal/CLIReadme.md
@@ -40,7 +40,7 @@ the target group of CICS regions\.
 	* Specifies the name of the CICS BUNDLE resource (up to 8 characters) to deploy or
 undeploy.
 
-*   `--bundledir`  | `--bd` *(string)*
+*   `--bundle-directory`  | `--bd` | `--bundledir` *(string)*
 
 	* Specifies the location of the CICS bundle (up to 255 characters) on zFS.
 
@@ -59,28 +59,28 @@ to target. Use this parameter if you have not set the --cics-deploy-profile
 option. For help on creating a profile issue the 'zowe profiles create
 cics-deploy --help' command.
 
-*   `--csdgroup`  | `--cg` *(string)*
+*   `--csd-group`  | `--cg` | `--csdgroup` *(string)*
 
 	* Specifies the CSD group (up to 8 characters) for the bundle resource. If a
-bundle is deployed then a definition is added to this group; if a bundle is
-undeployed then the definition is removed from this group. The definition is
+bundle is deployed, a definition is added to this group. If a bundle is
+undeployed, then the definition is removed from this group. The definition is
 added or removed from the CSD of each system that is specified by the --scope
 option. The --csdgroup and --resgroup options are mutually exclusive.
 
-*   `--resgroup`  | `--rg` *(string)*
+*   `--res-group`  | `--rg` | `--resgroup` *(string)*
 
 	* Specifies the BAS resource group (up to 8 characters) for the bundle resource.
-If a bundle is deployed then a resource is defined in the BAS data repository;
-if a bundle is undeployed then the definition is removed. The --csdgroup and
---resgroup options are mutually exclusive.
+If a bundle is deployed, a resource is defined in the BAS data repository. If a
+bundle is undeployed, the definition is removed. The --csdgroup and --resgroup
+options are mutually exclusive.
 
-*   `--cicshlq`  | `--hlq` *(string)*
+*   `--cics-hlq`  | `--ch` | `--cicshlq` *(string)*
 
 	* Specifies the high-level qualifier (up to 35 characters) at which the CICS
 datasets can be found in the target environment. Use this parameter if you have
 not set the --cics-deploy-profile option.
 
-*   `--cpsmhlq`  | `--cphlq` *(string)*
+*   `--cpsm-hlq`  | `--cph` | `--cpsmhlq` *(string)*
 
 	* Specifies the high-level qualifier (up to 35 characters) at which the CPSM
 datasets can be found in the target environment. Use this parameter if you have
@@ -91,7 +91,7 @@ not set the --cics-deploy-profile option.
 	* An optional value that specifies a description of the bundle definition (up to
 58 characters).
 
-*   `--jobcard`  | `--jc` *(string)*
+*   `--job-card`  | `--jc` | `--jobcard` *(string)*
 
 	* Specifies the job card to use with any generated DFHDPLOY JCL. Use this
 parameter if you need to tailor the job card and you have not set the
@@ -105,7 +105,7 @@ Default value: //DFHDPLOY JOB DFHDPLOY,CLASS=A,MSGCLASS=X,TIME=NOLIMIT
 	* An optional numerical value that specifies the maximum amount of time in seconds
 (1 - 1800 inclusive) for the DFHDPLOY command to complete.
 
-*   `--targetstate`  | `--ts` *(string)*
+*   `--target-state`  | `--ts` | `--targetstate` *(string)*
 
 	* Specifies the target state for the deployed bundle.
 
@@ -131,25 +131,26 @@ Allowed values: DISABLED, ENABLED, AVAILABLE
    *-  Deploy a CICS bundle with a specific name and location to a
    default set of target regions:
 
-* `          $  zowe deploy bundle --name EXAMPLE --bundledir /u/example/bundleDir`
+* `          $  zowe deploy bundle --name EXAMPLE --bundle-directory /u/example/bundleDir`
 
-   *-  Deploy a CICS bundle, but declare a timeout should the
-   processing take too long:
+   *-  Deploy a CICS bundle, but declare a timeout if the
+   processing takes too long:
 
-* `          $  zowe deploy bundle --name EXAMPLE --bundledir /u/example/bundleDir --timeout 60`
+* `          $  zowe deploy bundle --name EXAMPLE --bundle-directory /u/example/bundleDir --timeout 60`
 
-   *-  Deploy a CICS bundle to a specific target environment using
-   specific zosmf & cics-deploy profiles:
+   *-  Deploy a CICS bundle to a specific target environment by
+   using specific zosmf & cics-deploy profiles:
 
-* `          $  zowe deploy bundle --name EXAMPLE --bundledir /u/example/bundleDir --cicsplex TESTPLEX --scope SCOPE --resgroup BUNDGRP --cicshlq CICSTS55.CICS720 --cpsmhlq CICSTS55.CPSM550 --zosmf-profile testplex --cics-deploy-profile devcics`
+* `          $  zowe deploy bundle --name EXAMPLE --bundle-directory /u/example/bundleDir --cicsplex TESTPLEX --scope SCOPE --res-group BUNDGRP --cics-hlq CICSTS55.CICS720 --cpsm-hlq CICSTS55.CPSM550 --zosmf-profile testplex --cics-deploy-profile devcics`
 
 # generate | g | gen<a name="module-generate"></a>
 Generate a CICS bundle and associated metadata files in the current working directory. This allows the application in the current working directory to be deployed to CICS.
 ## bundle<a name="command-bundle"></a>
 Generate a CICS bundle in the working directory\. The associated data is
 constructed from a combination of the command\-line options and the contents of
-package\.json\. If package\.json exists, no options are required, but if it does
-not exist both \-\-startscript and \-\-nodejsapp are required\.
+package\.json\. If package\.json exists, no options are required\. If
+package\.json does not exist, both \-\-startscript and \-\-nodejsapp are
+required\.
 
 #### Usage
 
@@ -157,40 +158,41 @@ not exist both \-\-startscript and \-\-nodejsapp are required\.
 
 #### Options
 
-*   `--bundleid`  | `-b` | `--id` | `--bid` *(string)*
+*   `--bundle-id`  | `-b` | `--id` | `--bundleid` *(string)*
 
 	* The ID for the generated CICS bundle, up to 64 characters. If no value is
-specified then a default value is created from the 'name' property in the
-package.json file in the current working directory.If the value is too long it
-will be truncated. If it contains characters not supported by CICS, each one
-will be replaced by an X.
+specified, a default value is created from the 'name' property in the
+package.json file in the current working directory. If the value is too long, it
+is truncated. If it contains characters that are not supported by CICS, each
+character is replaced by an X.
 
-*   `--bundleversion`  | `--bv` | `--bundlever` *(string)*
+*   `--bundle-version`  | `--bv` | `--bundleversion` *(string)*
 
-	* The major.minor.micro version number for the generated CICS Bundle. If no value
-is specified then a default value of 1.0.0 is used.
+	* The major.minor.micro version number for the generated CICS bundle. If no value
+is specified, a default value of 1.0.0 is used.
 
 *   `--nodejsapp`  | `-n` | `--nj` | `--nja` *(string)*
 
 	* The ID of the generated CICS NODEJSAPP resource, up to 32 characters. If no
-value is specified then a default value is created from the 'name' property in
+value is specified, a default value is created from the 'name' property in
 package.json, or the bundleid option if specified. If the value is too long it
-will be truncated. If it contains characters not supported by CICS, each one
-will be replaced by an X.
+is truncated. If it contains characters that are not supported by CICS, each
+character is replaced by an X.
 
-*   `--startscript`  | `-s` | `--ss` *(string)*
+*   `--start-script`  | `-s` | `--ss` | `--startscript` *(string)*
 
-	* Up to 255 character path to the Node.js start script that should run when the
-associated bundle is enabled in CICS. If a value is not specified then a default
+	* Up to 255 character path to the Node.js start script that runs when the
+associated bundle is enabled in CICS. If a value is not specified, a default
 value is created from either the 'scripts.start' property of the package.json
 file in the current working directory, or from the 'main' property.
 
 *   `--port`  | `-p` *(string)*
 
-	* An optional TCP/IP port number that the Node.js application will expect to use.
-If a value is specified then it is stored within the generated NODEJSAPP's
-profile and the associated value can be referenced programatically using the
-'PORT' environment variable.
+	* The TCP/IP port number the Node.js application should use for clients to connect
+to. If a value is specified, it is set within the generated NODEJSAPP's profile.
+The Node.js application can reference this value by accessing the PORT
+environment variable, for example using process.env.PORT. Additional environment
+variables can be set by manually editing the profile.
 
 *   `--overwrite`  | `--ow` *(boolean)*
 
@@ -211,12 +213,12 @@ bundle manifest.
    *-  Generate a CICS bundle in the working directory, based on
    package.json but using a bundle ID of "mybundle":
 
-* `          $  zowe generate bundle --bundleid mybundle`
+* `          $  zowe generate bundle --bundle-id mybundle`
 
-   *-  Generate a CICS bundle in the working directory in which
-   there is no package.json:
+   *-  Generate a CICS bundle in the working directory in which a
+   package.json does not exist:
 
-* `          $  zowe generate bundle --bundleid mybundle --nodejsapp myapp --startscript server.js`
+* `          $  zowe generate bundle --bundle-id mybundle --nodejsapp myapp --start-script server.js`
 
 # profiles<a name="module-profiles"></a>
 Create and manage configuration profiles
@@ -248,17 +250,17 @@ using the name on commands that support the "--cics-deploy-profile" option.
 	* Specifies the name of the CICS System, or CICS System Group (up to 8 characters)
 to target.
 
-*   `--cicshlq`  | `--hlq` *(string)*
+*   `--cics-hlq`  | `--ch` | `--cicshlq` *(string)*
 
 	* Specifies the High Level Qualifier (up to 35 characters) at which the CICS
 datasets can be found in the target environment.
 
-*   `--cpsmhlq`  | `--cphlq` *(string)*
+*   `--cpsm-hlq`  | `--cph` | `--cpsmhlq` *(string)*
 
 	* Specifies the High Level Qualifier (up to 35 characters) at which the CPSM
 datasets can be found in the target environment.
 
-*   `--jobcard`  | `--jc` *(string)*
+*   `--job-card`  | `--jc` | `--jobcard` *(string)*
 
 	* Specifies the job card to use with any generated DFHDPLOY JCL.
 
@@ -266,7 +268,7 @@ Default value: //DFHDPLOY JOB DFHDPLOY,CLASS=A,MSGCLASS=X,TIME=NOLIMIT
 
 #### Options
 
-*   `--csdgroup`  | `--cg` *(string)*
+*   `--csd-group`  | `--cg` | `--csdgroup` *(string)*
 
 	* Specifies the CSD group (up to 8 characters) for the bundle resource. If a
 bundle is deployed then a definition is added to this group; if a bundle is
@@ -274,14 +276,14 @@ undeployed then the definition is removed from this group. The CSD group is
 changed for each CICS system that is specified by the --scope option. The
 --csdgroup and --resgroup options are mutually exclusive.
 
-*   `--resgroup`  | `--rg` *(string)*
+*   `--res-group`  | `--rg` | `--resgroup` *(string)*
 
 	* Specifies the BAS resource group (up to 8 characters) for the bundle resource.
 If a bundle is deployed then a resource is defined in the BAS data repository;
 if a bundle is undeployed then the definition is removed. The --csdgroup and
 --resgroup options are mutually exclusive.
 
-*   `--targetdir`  | `--td` *(string)*
+*   `--target-directory`  | `--td` | `--targetdir` *(string)*
 
 	* Specifies the target zFS location to which CICS bundles should be uploaded (up
 to 255 characters).
@@ -296,19 +298,19 @@ to 255 characters).
    to a CPSM managed group of CICS regions within the TESTGRP1 scope of a cicsplex
    named PLEX1:
 
-* `          $  zowe profiles create cics-deploy-profile example1 --cicsplex PLEX1 --scope TESTGRP1 --cicshlq CICSTS55.CICS720 --cpsmhlq CICSTS55.CPSM550`
+* `          $  zowe profiles create cics-deploy-profile example1 --cicsplex PLEX1 --scope TESTGRP1 --cics-hlq CICSTS55.CICS720 --cpsm-hlq CICSTS55.CPSM550`
 
    *-  Create a cics-deploy profile called 'example2' to connect
    to the same CPSM managed group of regions, and identify a BAS resource group
    BUNDGRP1 in which to store resource definitions:
 
-* `          $  zowe profiles create cics-deploy-profile example2 --cicsplex PLEX1 --scope TESTGRP1 --cicshlq CICSTS55.CICS720 --cpsmhlq CICSTS55.CPSM550 --resgroup BUNDGRP1`
+* `          $  zowe profiles create cics-deploy-profile example2 --cicsplex PLEX1 --scope TESTGRP1 --cics-hlq CICSTS55.CICS720 --cpsm-hlq CICSTS55.CPSM550 --res-group BUNDGRP1`
 
    *-  Create a cics-deploy profile called 'example3' to connect
    to the same CPSM managed group of regions, and identify the default USS
    directory to which bundles should be uploaded:
 
-* `          $  zowe profiles create cics-deploy-profile example3 --cicsplex PLEX1 --scope TESTGRP1 --cicshlq CICSTS55.CICS720 --cpsmhlq CICSTS55.CPSM550 --targetdir /var/cicsts/bundles`
+* `          $  zowe profiles create cics-deploy-profile example3 --cicsplex PLEX1 --scope TESTGRP1 --cics-hlq CICSTS55.CICS720 --cpsm-hlq CICSTS55.CPSM550 --target-directory /var/cicsts/bundles`
 
 ## update | upd<a name="module-update"></a>
 Update a  profile.You can update any property present within the profile configuration. The updated profile  will be printed so that you can review the result of the updates.
@@ -338,7 +340,7 @@ using the name on commands that support the "--cics-deploy-profile" option.
 	* Specifies the name of the CICS System, or CICS System Group (up to 8 characters)
 to target.
 
-*   `--csdgroup`  | `--cg` *(string)*
+*   `--csd-group`  | `--cg` | `--csdgroup` *(string)*
 
 	* Specifies the CSD group (up to 8 characters) for the bundle resource. If a
 bundle is deployed then a definition is added to this group; if a bundle is
@@ -346,29 +348,29 @@ undeployed then the definition is removed from this group. The CSD group is
 changed for each CICS system that is specified by the --scope option. The
 --csdgroup and --resgroup options are mutually exclusive.
 
-*   `--resgroup`  | `--rg` *(string)*
+*   `--res-group`  | `--rg` | `--resgroup` *(string)*
 
 	* Specifies the BAS resource group (up to 8 characters) for the bundle resource.
 If a bundle is deployed then a resource is defined in the BAS data repository;
 if a bundle is undeployed then the definition is removed. The --csdgroup and
 --resgroup options are mutually exclusive.
 
-*   `--cicshlq`  | `--hlq` *(string)*
+*   `--cics-hlq`  | `--ch` | `--cicshlq` *(string)*
 
 	* Specifies the High Level Qualifier (up to 35 characters) at which the CICS
 datasets can be found in the target environment.
 
-*   `--cpsmhlq`  | `--cphlq` *(string)*
+*   `--cpsm-hlq`  | `--cph` | `--cpsmhlq` *(string)*
 
 	* Specifies the High Level Qualifier (up to 35 characters) at which the CPSM
 datasets can be found in the target environment.
 
-*   `--targetdir`  | `--td` *(string)*
+*   `--target-directory`  | `--td` | `--targetdir` *(string)*
 
 	* Specifies the target zFS location to which CICS bundles should be uploaded (up
 to 255 characters).
 
-*   `--jobcard`  | `--jc` *(string)*
+*   `--job-card`  | `--jc` | `--jobcard` *(string)*
 
 	* Specifies the job card to use with any generated DFHDPLOY JCL.
 
@@ -477,9 +479,9 @@ Push a CICS bundle from the working directory to a target CICSplex\.
 	* Specifies the name of the CICS BUNDLE resource (up to 8 characters) to deploy or
 undeploy.
 
-*   `--targetdir`  | `--td` *(string)*
+*   `--target-directory`  | `--td` | `--targetdir` *(string)*
 
-	* Specifies the target zFS location in which the CICS bundle should be created (up
+	* Specifies the target zFS location in which the CICS bundle is to be created (up
 to 255 characters)
 
 #### Options
@@ -497,28 +499,28 @@ to target. Use this parameter if you have not set the --cics-deploy-profile
 option. For help on creating a profile issue the 'zowe profiles create
 cics-deploy --help' command.
 
-*   `--csdgroup`  | `--cg` *(string)*
+*   `--csd-group`  | `--cg` | `--csdgroup` *(string)*
 
 	* Specifies the CSD group (up to 8 characters) for the bundle resource. If a
-bundle is deployed then a definition is added to this group; if a bundle is
-undeployed then the definition is removed from this group. The definition is
+bundle is deployed, a definition is added to this group. If a bundle is
+undeployed, then the definition is removed from this group. The definition is
 added or removed from the CSD of each system that is specified by the --scope
 option. The --csdgroup and --resgroup options are mutually exclusive.
 
-*   `--resgroup`  | `--rg` *(string)*
+*   `--res-group`  | `--rg` | `--resgroup` *(string)*
 
 	* Specifies the BAS resource group (up to 8 characters) for the bundle resource.
-If a bundle is deployed then a resource is defined in the BAS data repository;
-if a bundle is undeployed then the definition is removed. The --csdgroup and
---resgroup options are mutually exclusive.
+If a bundle is deployed, a resource is defined in the BAS data repository. If a
+bundle is undeployed, the definition is removed. The --csdgroup and --resgroup
+options are mutually exclusive.
 
-*   `--cicshlq`  | `--hlq` *(string)*
+*   `--cics-hlq`  | `--ch` | `--cicshlq` *(string)*
 
 	* Specifies the high-level qualifier (up to 35 characters) at which the CICS
 datasets can be found in the target environment. Use this parameter if you have
 not set the --cics-deploy-profile option.
 
-*   `--cpsmhlq`  | `--cphlq` *(string)*
+*   `--cpsm-hlq`  | `--cph` | `--cpsmhlq` *(string)*
 
 	* Specifies the high-level qualifier (up to 35 characters) at which the CPSM
 datasets can be found in the target environment. Use this parameter if you have
@@ -529,7 +531,7 @@ not set the --cics-deploy-profile option.
 	* An optional value that specifies a description of the bundle definition (up to
 58 characters).
 
-*   `--jobcard`  | `--jc` *(string)*
+*   `--job-card`  | `--jc` | `--jobcard` *(string)*
 
 	* Specifies the job card to use with any generated DFHDPLOY JCL. Use this
 parameter if you need to tailor the job card and you have not set the
@@ -543,7 +545,7 @@ Default value: //DFHDPLOY JOB DFHDPLOY,CLASS=A,MSGCLASS=X,TIME=NOLIMIT
 	* An optional numerical value that specifies the maximum amount of time in seconds
 (1 - 1800 inclusive) for the DFHDPLOY command to complete.
 
-*   `--targetstate`  | `--ts` *(string)*
+*   `--target-state`  | `--ts` | `--targetstate` *(string)*
 
 	* Specifies the target state for the deployed bundle.
 
@@ -575,20 +577,20 @@ on the remote system.
 
 ### Examples
 
-   *-  Push a CICS bundle from the working directory using default
-   cics-deploy, ssh and zosmf profiles:
+   *-  Push a CICS bundle from the working directory by using
+   default cics-deploy, ssh and zosmf profiles:
 
-* `          $  zowe push bundle --name EXAMPLE --targetdir /u/example/bundles`
+* `          $  zowe push bundle --name EXAMPLE --target-directory /u/example/bundles`
 
-   *-  Push a CICS bundle from the working directory using
+   *-  Push a CICS bundle from the working directory by using
    specific zosmf, ssh & cics-deploy profiles:
 
-* `          $  zowe push bundle --name EXAMPLE --targetdir /u/example/bundles --zosmf-profile testplex --cics-deploy-profile devcics --ssh-profile ssh`
+* `          $  zowe push bundle --name EXAMPLE --target-directory /u/example/bundles --zosmf-profile testplex --cics-deploy-profile devcics --ssh-profile ssh`
 
    *-  Push a CICS bundle from the working directory replacing any
    bundle of the same name that is already deployed:
 
-* `          $  zowe push bundle --name EXAMPLE --targetdir /u/example/bundles --overwrite`
+* `          $  zowe push bundle --name EXAMPLE --target-directory /u/example/bundles --overwrite`
 
 # undeploy | u | udep<a name="module-undeploy"></a>
 Undeploy a CICS bundle from one or more CICS regions within a CICSplex. A BUNDLE resource is made UNAVAILABLE, it is then DISABLED and DISCARDED from the target scope with the CICSplex.
@@ -623,34 +625,34 @@ to target. Use this parameter if you have not set the --cics-deploy-profile
 option. For help on creating a profile issue the 'zowe profiles create
 cics-deploy --help' command.
 
-*   `--csdgroup`  | `--cg` *(string)*
+*   `--csd-group`  | `--cg` | `--csdgroup` *(string)*
 
 	* Specifies the CSD group (up to 8 characters) for the bundle resource. If a
-bundle is deployed then a definition is added to this group; if a bundle is
-undeployed then the definition is removed from this group. The definition is
+bundle is deployed, a definition is added to this group. If a bundle is
+undeployed, then the definition is removed from this group. The definition is
 added or removed from the CSD of each system that is specified by the --scope
 option. The --csdgroup and --resgroup options are mutually exclusive.
 
-*   `--resgroup`  | `--rg` *(string)*
+*   `--res-group`  | `--rg` | `--resgroup` *(string)*
 
 	* Specifies the BAS resource group (up to 8 characters) for the bundle resource.
-If a bundle is deployed then a resource is defined in the BAS data repository;
-if a bundle is undeployed then the definition is removed. The --csdgroup and
---resgroup options are mutually exclusive.
+If a bundle is deployed, a resource is defined in the BAS data repository. If a
+bundle is undeployed, the definition is removed. The --csdgroup and --resgroup
+options are mutually exclusive.
 
-*   `--cicshlq`  | `--hlq` *(string)*
+*   `--cics-hlq`  | `--ch` | `--cicshlq` *(string)*
 
 	* Specifies the high-level qualifier (up to 35 characters) at which the CICS
 datasets can be found in the target environment. Use this parameter if you have
 not set the --cics-deploy-profile option.
 
-*   `--cpsmhlq`  | `--cphlq` *(string)*
+*   `--cpsm-hlq`  | `--cph` | `--cpsmhlq` *(string)*
 
 	* Specifies the high-level qualifier (up to 35 characters) at which the CPSM
 datasets can be found in the target environment. Use this parameter if you have
 not set the --cics-deploy-profile option.
 
-*   `--jobcard`  | `--jc` *(string)*
+*   `--job-card`  | `--jc` | `--jobcard` *(string)*
 
 	* Specifies the job card to use with any generated DFHDPLOY JCL. Use this
 parameter if you need to tailor the job card and you have not set the
@@ -664,7 +666,7 @@ Default value: //DFHDPLOY JOB DFHDPLOY,CLASS=A,MSGCLASS=X,TIME=NOLIMIT
 	* An optional numerical value that specifies the maximum amount of time in seconds
 (1 - 1800 inclusive) for the DFHDPLOY command to complete.
 
-*   `--targetstate`  | `--ts` *(string)*
+*   `--target-state`  | `--ts` | `--targetstate` *(string)*
 
 	* Specifies the target state for the undeployed bundle.
 
@@ -687,18 +689,18 @@ Allowed values: UNAVAILABLE, DISABLED, DISCARDED
 
 ### Examples
 
-   *-  Undeploy a CICS bundle using the default cics-deploy
+   *-  Undeploy a CICS bundle by using the default cics-deploy
    profile:
 
 * `          $  zowe undeploy bundle --name EXAMPLE`
 
-   *-  Undeploy a CICS bundle, and declare a timeout should the
-   processing take too long:
+   *-  Undeploy a CICS bundle, and declare a timeout if the
+   processing takes too long:
 
 * `          $  zowe undeploy bundle --name EXAMPLE --timeout 60`
 
    *-  Undeploy a CICS bundle from a specific target environment
-   using specific zosmf and cics-deploy profiles:
+   by using specific zosmf and cics-deploy profiles:
 
-* `          $  zowe undeploy bundle --name EXAMPLE --cicsplex TESTPLEX --scope SCOPE --resgroup BUNDGRP --cicshlq CICSTS55.CICS720 --cpsmhlq CICSTS55.CPSM550 --zosmf-profile testplex --cics-deploy-profile devcics`
+* `          $  zowe undeploy bundle --name EXAMPLE --cics-plex TESTPLEX --scope SCOPE --res-group BUNDGRP --cics-hlq CICSTS55.CICS720 --cpsm-hlq CICSTS55.CPSM550 --zosmf-profile testplex --cics-deploy-profile devcics`
 

--- a/docs-internal/CLIReadme.md
+++ b/docs-internal/CLIReadme.md
@@ -65,13 +65,13 @@ cics-deploy --help' command.
 bundle is deployed, a definition is added to this group. If a bundle is
 undeployed, then the definition is removed from this group. The definition is
 added or removed from the CSD of each system that is specified by the --scope
-option. The --csdgroup and --resgroup options are mutually exclusive.
+option. The --csd-group and --res-group options are mutually exclusive.
 
 *   `--res-group`  | `--rg` | `--resgroup` *(string)*
 
 	* Specifies the BAS resource group (up to 8 characters) for the bundle resource.
 If a bundle is deployed, a resource is defined in the BAS data repository. If a
-bundle is undeployed, the definition is removed. The --csdgroup and --resgroup
+bundle is undeployed, the definition is removed. The --csd-group and --res-group
 options are mutually exclusive.
 
 *   `--cics-hlq`  | `--ch` | `--cicshlq` *(string)*
@@ -149,7 +149,7 @@ Generate a CICS bundle and associated metadata files in the current working dire
 Generate a CICS bundle in the working directory\. The associated data is
 constructed from a combination of the command\-line options and the contents of
 package\.json\. If package\.json exists, no options are required\. If
-package\.json does not exist, both \-\-startscript and \-\-nodejsapp are
+package\.json does not exist, both \-\-start\-script and \-\-nodejsapp are
 required\.
 
 #### Usage
@@ -274,14 +274,14 @@ Default value: //DFHDPLOY JOB DFHDPLOY,CLASS=A,MSGCLASS=X,TIME=NOLIMIT
 bundle is deployed then a definition is added to this group; if a bundle is
 undeployed then the definition is removed from this group. The CSD group is
 changed for each CICS system that is specified by the --scope option. The
---csdgroup and --resgroup options are mutually exclusive.
+--csd-group and --res-group options are mutually exclusive.
 
 *   `--res-group`  | `--rg` | `--resgroup` *(string)*
 
 	* Specifies the BAS resource group (up to 8 characters) for the bundle resource.
 If a bundle is deployed then a resource is defined in the BAS data repository;
-if a bundle is undeployed then the definition is removed. The --csdgroup and
---resgroup options are mutually exclusive.
+if a bundle is undeployed then the definition is removed. The --csd-group and
+--res-group options are mutually exclusive.
 
 *   `--target-directory`  | `--td` | `--targetdir` *(string)*
 
@@ -346,14 +346,14 @@ to target.
 bundle is deployed then a definition is added to this group; if a bundle is
 undeployed then the definition is removed from this group. The CSD group is
 changed for each CICS system that is specified by the --scope option. The
---csdgroup and --resgroup options are mutually exclusive.
+--csd-group and --res-group options are mutually exclusive.
 
 *   `--res-group`  | `--rg` | `--resgroup` *(string)*
 
 	* Specifies the BAS resource group (up to 8 characters) for the bundle resource.
 If a bundle is deployed then a resource is defined in the BAS data repository;
-if a bundle is undeployed then the definition is removed. The --csdgroup and
---resgroup options are mutually exclusive.
+if a bundle is undeployed then the definition is removed. The --csd-group and
+--res-group options are mutually exclusive.
 
 *   `--cics-hlq`  | `--ch` | `--cicshlq` *(string)*
 
@@ -505,13 +505,13 @@ cics-deploy --help' command.
 bundle is deployed, a definition is added to this group. If a bundle is
 undeployed, then the definition is removed from this group. The definition is
 added or removed from the CSD of each system that is specified by the --scope
-option. The --csdgroup and --resgroup options are mutually exclusive.
+option. The --csd-group and --res-group options are mutually exclusive.
 
 *   `--res-group`  | `--rg` | `--resgroup` *(string)*
 
 	* Specifies the BAS resource group (up to 8 characters) for the bundle resource.
 If a bundle is deployed, a resource is defined in the BAS data repository. If a
-bundle is undeployed, the definition is removed. The --csdgroup and --resgroup
+bundle is undeployed, the definition is removed. The --csd-group and --res-group
 options are mutually exclusive.
 
 *   `--cics-hlq`  | `--ch` | `--cicshlq` *(string)*
@@ -631,13 +631,13 @@ cics-deploy --help' command.
 bundle is deployed, a definition is added to this group. If a bundle is
 undeployed, then the definition is removed from this group. The definition is
 added or removed from the CSD of each system that is specified by the --scope
-option. The --csdgroup and --resgroup options are mutually exclusive.
+option. The --csd-group and --res-group options are mutually exclusive.
 
 *   `--res-group`  | `--rg` | `--resgroup` *(string)*
 
 	* Specifies the BAS resource group (up to 8 characters) for the bundle resource.
 If a bundle is deployed, a resource is defined in the BAS data repository. If a
-bundle is undeployed, the definition is removed. The --csdgroup and --resgroup
+bundle is undeployed, the definition is removed. The --csd-group and --res-group
 options are mutually exclusive.
 
 *   `--cics-hlq`  | `--ch` | `--cicshlq` *(string)*

--- a/src/api/BundlePush/BundlePusher.ts
+++ b/src/api/BundlePush/BundlePusher.ts
@@ -372,7 +372,7 @@ export class BundlePusher {
       }
 
       this.sshOutputText = "";
-      const shell = await Shell.executeSshCwd(sshSession, sshCommand, directory, this.sshOutput.bind(this));
+      const sshReturnCode = await Shell.executeSshCwd(sshSession, sshCommand, directory, this.sshOutput.bind(this));
       const upperCaseOutputText = this.sshOutputText.toUpperCase();
 
       // Note that FSUM9195 can imply that we've tried to delete the
@@ -383,19 +383,19 @@ export class BundlePusher {
       const countFSUM9195 = (upperCaseOutputText.match(/FSUM9195/g) || []).length;
       if (countFSUM9195 !== 0 &&
           countFSUM === countFSUM9195 &&
-          shell === 1) {
+          sshReturnCode === 1) {
         isOnlyFSUM9195 = true;
       }
 
       // Now check
       // A. If exit code is non zero
       // B. FSUM9195 is not the only FSUM error
-      if (shell !== 0 && !isOnlyFSUM9195) {
+      if (sshReturnCode !== 0 && !isOnlyFSUM9195) {
         // if we've not already logged the output, log it now
         if (this.params.arguments.verbose !== true) {
           this.params.response.console.log(Buffer.from(this.sshOutputText));
         }
-        throw new Error("The output from the remote command implied that an error occurred, return code " + shell + ".");
+        throw new Error("The output from the remote command implied that an error occurred, return code " + sshReturnCode + ".");
       }
     }
     catch (error) {

--- a/src/api/BundlePush/BundlePusher.ts
+++ b/src/api/BundlePush/BundlePusher.ts
@@ -395,7 +395,7 @@ export class BundlePusher {
         if (this.params.arguments.verbose !== true) {
           this.params.response.console.log(Buffer.from(this.sshOutputText));
         }
-        throw new Error("The output from the remote command implied that an error occurred.");
+        throw new Error("The output from the remote command implied that an error occurred, return code " + shell + ".");
       }
     }
     catch (error) {

--- a/src/cli/deploy/bundle/DeployBundle.definition.ts
+++ b/src/cli/deploy/bundle/DeployBundle.definition.ts
@@ -44,16 +44,16 @@ export const DeployBundleDefinition: ICommandDefinition = {
     examples: [
         {
             description: "Deploy a CICS bundle with a specific name and location to a default set of target regions",
-            options: `--name EXAMPLE --bundledir /u/example/bundleDir`
+            options: `--name EXAMPLE --bundle-directory /u/example/bundleDir`
         },
         {
             description: "Deploy a CICS bundle, but declare a timeout if the processing takes too long",
-            options: `--name EXAMPLE --bundledir /u/example/bundleDir --timeout 60`
+            options: `--name EXAMPLE --bundle-directory /u/example/bundleDir --timeout 60`
         },
         {
             description: "Deploy a CICS bundle to a specific target environment by using specific zosmf & cics-deploy profiles",
-            options: `--name EXAMPLE --bundledir /u/example/bundleDir --cicsplex TESTPLEX --scope SCOPE --resgroup BUNDGRP ` +
-                     `--cicshlq CICSTS55.CICS720 --cpsmhlq CICSTS55.CPSM550 --zosmf-profile testplex --cics-deploy-profile devcics`
+            options: `--name EXAMPLE --bundle-directory /u/example/bundleDir --cicsplex TESTPLEX --scope SCOPE --res-group BUNDGRP ` +
+                     `--cics-hlq CICSTS55.CICS720 --cpsm-hlq CICSTS55.CPSM550 --zosmf-profile testplex --cics-deploy-profile devcics`
         }
     ]
 };

--- a/src/cli/deploy/bundle/options/Bundledir.option.ts
+++ b/src/cli/deploy/bundle/options/Bundledir.option.ts
@@ -19,7 +19,7 @@ const MAX_LENGTH = 255;
  */
 export const BundledirOption: ICommandOptionDefinition = {
     name: "bundle-directory",
-    aliases: ["bd", "bundledir"],
+    aliases: ["bd", "bundledir", "bundle-dir"],
     type: "string",
     required: true,
     stringLengthRange: [1, MAX_LENGTH],

--- a/src/cli/deploy/bundle/options/Bundledir.option.ts
+++ b/src/cli/deploy/bundle/options/Bundledir.option.ts
@@ -18,8 +18,8 @@ const MAX_LENGTH = 255;
  *
  */
 export const BundledirOption: ICommandOptionDefinition = {
-    name: "bundledir",
-    aliases: ["bd"],
+    name: "bundle-directory",
+    aliases: ["bd", "bundledir"],
     type: "string",
     required: true,
     stringLengthRange: [1, MAX_LENGTH],

--- a/src/cli/deploy/bundle/options/TargetState.option.ts
+++ b/src/cli/deploy/bundle/options/TargetState.option.ts
@@ -16,8 +16,8 @@ import { ICommandOptionDefinition } from "@zowe/imperative";
  *
  */
 export const TargetStateOption: ICommandOptionDefinition = {
-    name: "targetstate",
-    aliases: ["ts"],
+    name: "target-state",
+    aliases: ["ts", "targetstate"],
     type: "string",
     required: false,
     defaultValue: "ENABLED",

--- a/src/cli/generate/bundle/GenerateBundle.definition.ts
+++ b/src/cli/generate/bundle/GenerateBundle.definition.ts
@@ -41,11 +41,11 @@ export const GenerateBundleDefinition: ICommandDefinition = {
         },
         {
             description: "Generate a CICS bundle in the working directory, based on package.json but using a bundle ID of \"mybundle\"",
-            options: `--bundleid mybundle`
+            options: `--bundle-id mybundle`
         },
         {
             description: "Generate a CICS bundle in the working directory in which a package.json does not exist",
-            options: `--bundleid mybundle --nodejsapp myapp --startscript server.js`
+            options: `--bundle-id mybundle --nodejsapp myapp --start-script server.js`
         }
     ]
 };

--- a/src/cli/generate/bundle/GenerateBundle.definition.ts
+++ b/src/cli/generate/bundle/GenerateBundle.definition.ts
@@ -29,7 +29,7 @@ export const GenerateBundleDefinition: ICommandDefinition = {
     description: "Generate a CICS bundle in the working directory. " +
                  "The associated data is constructed from a combination of the " +
                  "command-line options and the contents of package.json. If package.json exists, " +
-                 "no options are required. If package.json does not exist, both --startscript and --nodejsapp are required.",
+                 "no options are required. If package.json does not exist, both --start-script and --nodejsapp are required.",
     type: "command",
     handler: __dirname + "/GenerateBundle.handler",
     options: [ BundleidOption, BundleversionOption, NodejsappOption, StartscriptOption, PortOption,

--- a/src/cli/generate/bundle/options/Bundleid.option.ts
+++ b/src/cli/generate/bundle/options/Bundleid.option.ts
@@ -16,8 +16,8 @@ import { ICommandOptionDefinition } from "@zowe/imperative";
  *
  */
 export const BundleidOption: ICommandOptionDefinition = {
-    name: "bundleid",
-    aliases: ["b", "id", "bid"],
+    name: "bundle-id",
+    aliases: ["b", "id", "bundleid"],
     type: "string",
     description: "The ID for the generated CICS bundle, up to 64 characters. If no value is " +
                  "specified, a default value is created from the 'name' property " +

--- a/src/cli/generate/bundle/options/Bundleversion.option.ts
+++ b/src/cli/generate/bundle/options/Bundleversion.option.ts
@@ -16,8 +16,8 @@ import { ICommandOptionDefinition } from "@zowe/imperative";
  *
  */
 export const BundleversionOption: ICommandOptionDefinition = {
-    name: "bundleversion",
-    aliases: ["bv", "bundlever"],
+    name: "bundle-version",
+    aliases: ["bv", "bundleversion"],
     type: "string",
     description: "The major.minor.micro version number for the generated CICS bundle. If no value is " +
                  "specified, a default value of 1.0.0 is used."

--- a/src/cli/generate/bundle/options/Startscript.option.ts
+++ b/src/cli/generate/bundle/options/Startscript.option.ts
@@ -16,8 +16,8 @@ import { ICommandOptionDefinition } from "@zowe/imperative";
  *
  */
 export const StartscriptOption: ICommandOptionDefinition = {
-    name: "startscript",
-    aliases: ["s", "ss"],
+    name: "start-script",
+    aliases: ["s", "ss", "startscript"],
     type: "string",
     description: "Up to 255 character path to the Node.js start script that runs when " +
                  "the associated bundle is enabled in CICS. If a value is not " +

--- a/src/cli/push/bundle/PushBundle.definition.ts
+++ b/src/cli/push/bundle/PushBundle.definition.ts
@@ -43,15 +43,15 @@ export const PushBundleDefinition: ICommandDefinition = {
     examples: [
         {
             description: "Push a CICS bundle from the working directory by using default cics-deploy, ssh and zosmf profiles",
-            options: `--name EXAMPLE --targetdir /u/example/bundles`
+            options: `--name EXAMPLE --target-directory /u/example/bundles`
         },
         {
             description: "Push a CICS bundle from the working directory by using specific zosmf, ssh & cics-deploy profiles",
-            options: `--name EXAMPLE --targetdir /u/example/bundles --zosmf-profile testplex --cics-deploy-profile devcics --ssh-profile ssh`
+            options: `--name EXAMPLE --target-directory /u/example/bundles --zosmf-profile testplex --cics-deploy-profile devcics --ssh-profile ssh`
         },
         {
             description: "Push a CICS bundle from the working directory replacing any bundle of the same name that is already deployed",
-            options: `--name EXAMPLE --targetdir /u/example/bundles --overwrite`
+            options: `--name EXAMPLE --target-directory /u/example/bundles --overwrite`
         }
     ]
 };

--- a/src/cli/push/bundle/options/Targetdir.option.ts
+++ b/src/cli/push/bundle/options/Targetdir.option.ts
@@ -19,7 +19,7 @@ const MAX_LENGTH = 255;
  */
 export const TargetdirOption: ICommandOptionDefinition = {
     name: "target-directory",
-    aliases: ["td", "targetdir"],
+    aliases: ["td", "targetdir", "target-dir"],
     type: "string",
     required: true,
     stringLengthRange: [1, MAX_LENGTH],

--- a/src/cli/push/bundle/options/Targetdir.option.ts
+++ b/src/cli/push/bundle/options/Targetdir.option.ts
@@ -18,8 +18,8 @@ const MAX_LENGTH = 255;
  *
  */
 export const TargetdirOption: ICommandOptionDefinition = {
-    name: "targetdir",
-    aliases: ["td"],
+    name: "target-directory",
+    aliases: ["td", "targetdir"],
     type: "string",
     required: true,
     stringLengthRange: [1, MAX_LENGTH],

--- a/src/cli/shared/Cicshlq.option.ts
+++ b/src/cli/shared/Cicshlq.option.ts
@@ -18,8 +18,8 @@ const MAX_LENGTH = 35;
  *
  */
 export const CicshlqOption: ICommandOptionDefinition = {
-    name: "cicshlq",
-    aliases: ["hlq"],
+    name: "cics-hlq",
+    aliases: ["ch", "cicshlq"],
     type: "string",
     required: false,
     stringLengthRange: [1, MAX_LENGTH],

--- a/src/cli/shared/Cpsmhlq.option.ts
+++ b/src/cli/shared/Cpsmhlq.option.ts
@@ -18,8 +18,8 @@ const MAX_LENGTH = 35;
  *
  */
 export const CpsmhlqOption: ICommandOptionDefinition = {
-    name: "cpsmhlq",
-    aliases: ["cphlq"],
+    name: "cpsm-hlq",
+    aliases: ["cph", "cpsmhlq"],
     type: "string",
     required: false,
     stringLengthRange: [1, MAX_LENGTH],

--- a/src/cli/shared/Csdgroup.option.ts
+++ b/src/cli/shared/Csdgroup.option.ts
@@ -18,8 +18,8 @@ const MAX_LENGTH = 8;
  *
  */
 export const CsdgroupOption: ICommandOptionDefinition = {
-    name: "csdgroup",
-    aliases: ["cg"],
+    name: "csd-group",
+    aliases: ["cg", "csdgroup"],
     type: "string",
     stringLengthRange: [1, MAX_LENGTH],
     description: "Specifies the CSD group (up to 8 characters) for the bundle resource. If a bundle is " +

--- a/src/cli/shared/Csdgroup.option.ts
+++ b/src/cli/shared/Csdgroup.option.ts
@@ -25,7 +25,7 @@ export const CsdgroupOption: ICommandOptionDefinition = {
     description: "Specifies the CSD group (up to 8 characters) for the bundle resource. If a bundle is " +
                  "deployed, a definition is added to this group. If a bundle is undeployed, then the " +
                  "definition is removed from this group. The definition is added or removed from the CSD of each system " +
-                 "that is specified by the --scope option. The --csdgroup and --resgroup options are " +
+                 "that is specified by the --scope option. The --csd-group and --res-group options are " +
                  "mutually exclusive."
 };
 

--- a/src/cli/shared/Jobcard.option.ts
+++ b/src/cli/shared/Jobcard.option.ts
@@ -16,8 +16,8 @@ import { ICommandOptionDefinition } from "@zowe/imperative";
  *
  */
 export const JobcardOption: ICommandOptionDefinition = {
-    name: "jobcard",
-    aliases: ["jc"],
+    name: "job-card",
+    aliases: ["jc", "jobcard"],
     type: "string",
     description: "Specifies the job card to use with any generated DFHDPLOY JCL. Use this parameter " +
                  "if you need to tailor the job card and you have not set the --cics-deploy-profile " +

--- a/src/cli/shared/Resgroup.option.ts
+++ b/src/cli/shared/Resgroup.option.ts
@@ -18,8 +18,8 @@ const MAX_LENGTH = 8;
  *
  */
 export const ResgroupOption: ICommandOptionDefinition = {
-    name: "resgroup",
-    aliases: ["rg"],
+    name: "res-group",
+    aliases: ["rg", "resgroup"],
     type: "string",
     stringLengthRange: [1, MAX_LENGTH],
     conflictsWith: [ "csdgroup" ],

--- a/src/cli/shared/Resgroup.option.ts
+++ b/src/cli/shared/Resgroup.option.ts
@@ -25,7 +25,7 @@ export const ResgroupOption: ICommandOptionDefinition = {
     conflictsWith: [ "csdgroup" ],
     description: "Specifies the BAS resource group (up to 8 characters) for the bundle resource. If a bundle is " +
                  "deployed, a resource is defined in the BAS data repository. If a bundle is undeployed, the " +
-                 "definition is removed. The --csdgroup and --resgroup options are " +
+                 "definition is removed. The --csd-group and --res-group options are " +
                  "mutually exclusive."
 };
 

--- a/src/cli/undeploy/bundle/UndeployBundle.definition.ts
+++ b/src/cli/undeploy/bundle/UndeployBundle.definition.ts
@@ -50,8 +50,8 @@ export const UndeployBundleDefinition: ICommandDefinition = {
         },
         {
             description: "Undeploy a CICS bundle from a specific target environment by using specific zosmf and cics-deploy profiles",
-            options: `--name EXAMPLE --cicsplex TESTPLEX --scope SCOPE --resgroup BUNDGRP ` +
-                     `--cicshlq CICSTS55.CICS720 --cpsmhlq CICSTS55.CPSM550 --zosmf-profile testplex --cics-deploy-profile devcics`
+            options: `--name EXAMPLE --cics-plex TESTPLEX --scope SCOPE --res-group BUNDGRP ` +
+                     `--cics-hlq CICSTS55.CICS720 --cpsm-hlq CICSTS55.CPSM550 --zosmf-profile testplex --cics-deploy-profile devcics`
         }
     ]
 };

--- a/src/cli/undeploy/bundle/options/TargetState.option.ts
+++ b/src/cli/undeploy/bundle/options/TargetState.option.ts
@@ -16,8 +16,8 @@ import { ICommandOptionDefinition } from "@zowe/imperative";
  *
  */
 export const TargetStateOption: ICommandOptionDefinition = {
-    name: "targetstate",
-    aliases: ["ts"],
+    name: "target-state",
+    aliases: ["ts", "targetstate"],
     type: "string",
     required: false,
     defaultValue: "DISCARDED",

--- a/src/imperative.ts
+++ b/src/imperative.ts
@@ -111,7 +111,7 @@ const config: IImperativeConfig = {
                 description: "Specifies the target zFS location to which CICS bundles should be uploaded (up to 255 characters).",
                 type: "string",
                 name: "target-directory",
-                aliases: ["td", "targetdir"],
+                aliases: ["td", "targetdir", "target-dir"],
                 stringLengthRange: [1, MAX_TARGETDIR_LENGTH],
                 required: false
               },

--- a/src/imperative.ts
+++ b/src/imperative.ts
@@ -60,7 +60,7 @@ const config: IImperativeConfig = {
                 description: "Specifies the CSD group (up to 8 characters) for the bundle resource. If a bundle is " +
                              "deployed then a definition is added to this group; if a bundle is undeployed then the " +
                              "definition is removed from this group. The CSD group is changed for each CICS system " +
-                             "that is specified by the --scope option. The --csdgroup and --resgroup options are " +
+                             "that is specified by the --scope option. The --csd-group and --res-group options are " +
                              "mutually exclusive.",
                 type: "string",
                 name: "csd-group",
@@ -73,7 +73,7 @@ const config: IImperativeConfig = {
               optionDefinition: {
                 description: "Specifies the BAS resource group (up to 8 characters) for the bundle resource. If a bundle is " +
                              "deployed then a resource is defined in the BAS data repository; if a bundle is undeployed then the " +
-                             "definition is removed. The --csdgroup and --resgroup options are mutually exclusive.",
+                             "definition is removed. The --csd-group and --res-group options are mutually exclusive.",
                 type: "string",
                 name: "res-group",
                 aliases: ["rg", "resgroup"],

--- a/src/imperative.ts
+++ b/src/imperative.ts
@@ -63,8 +63,8 @@ const config: IImperativeConfig = {
                              "that is specified by the --scope option. The --csdgroup and --resgroup options are " +
                              "mutually exclusive.",
                 type: "string",
-                name: "csdgroup",
-                aliases: ["cg"],
+                name: "csd-group",
+                aliases: ["cg", "csdgroup"],
                 stringLengthRange: [1, MAX_LENGTH]
               },
               type: "string"
@@ -75,8 +75,8 @@ const config: IImperativeConfig = {
                              "deployed then a resource is defined in the BAS data repository; if a bundle is undeployed then the " +
                              "definition is removed. The --csdgroup and --resgroup options are mutually exclusive.",
                 type: "string",
-                name: "resgroup",
-                aliases: ["rg"],
+                name: "res-group",
+                aliases: ["rg", "resgroup"],
                 stringLengthRange: [1, MAX_LENGTH],
                 conflictsWith: [ "csdgroup" ],
               },
@@ -87,8 +87,8 @@ const config: IImperativeConfig = {
                 description: "Specifies the High Level Qualifier (up to 35 characters) at which the CICS " +
                              "datasets can be found in the target environment.",
                 type: "string",
-                name: "cicshlq",
-                aliases: ["hlq"],
+                name: "cics-hlq",
+                aliases: ["ch", "cicshlq"],
                 stringLengthRange: [1, MAX_HLQ_LENGTH],
                 required: true
               },
@@ -99,8 +99,8 @@ const config: IImperativeConfig = {
                 description: "Specifies the High Level Qualifier (up to 35 characters) at which the CPSM " +
                              "datasets can be found in the target environment.",
                 type: "string",
-                name: "cpsmhlq",
-                aliases: ["cphlq"],
+                name: "cpsm-hlq",
+                aliases: ["cph", "cpsmhlq"],
                 stringLengthRange: [1, MAX_HLQ_LENGTH],
                 required: true
               },
@@ -110,8 +110,8 @@ const config: IImperativeConfig = {
               optionDefinition: {
                 description: "Specifies the target zFS location to which CICS bundles should be uploaded (up to 255 characters).",
                 type: "string",
-                name: "targetdir",
-                aliases: ["td"],
+                name: "target-directory",
+                aliases: ["td", "targetdir"],
                 stringLengthRange: [1, MAX_TARGETDIR_LENGTH],
                 required: false
               },
@@ -121,9 +121,9 @@ const config: IImperativeConfig = {
               optionDefinition: {
                 description: "Specifies the job card to use with any generated DFHDPLOY JCL.",
                 type: "string",
-                name: "jobcard",
+                name: "job-card",
                 defaultValue: "//DFHDPLOY JOB DFHDPLOY,CLASS=A,MSGCLASS=X,TIME=NOLIMIT",
-                aliases: ["jc"],
+                aliases: ["jc", "jobcard"],
                 required: true
               },
               type: "string"
@@ -133,18 +133,18 @@ const config: IImperativeConfig = {
         },
         createProfileExamples: [
           {
-            options: "example1 --cicsplex PLEX1 --scope TESTGRP1 --cicshlq CICSTS55.CICS720 --cpsmhlq CICSTS55.CPSM550",
+            options: "example1 --cicsplex PLEX1 --scope TESTGRP1 --cics-hlq CICSTS55.CICS720 --cpsm-hlq CICSTS55.CPSM550",
             description: "Create a cics-deploy profile called 'example1' to connect to a CPSM managed group of CICS regions " +
                          "within the TESTGRP1 scope of a cicsplex named PLEX1"
           },
           {
-            options: "example2 --cicsplex PLEX1 --scope TESTGRP1 --cicshlq CICSTS55.CICS720 --cpsmhlq CICSTS55.CPSM550 --resgroup BUNDGRP1",
+            options: "example2 --cicsplex PLEX1 --scope TESTGRP1 --cics-hlq CICSTS55.CICS720 --cpsm-hlq CICSTS55.CPSM550 --res-group BUNDGRP1",
             description: "Create a cics-deploy profile called 'example2' to connect to the same CPSM managed group of regions, " +
                          "and identify a BAS resource group BUNDGRP1 in which to store resource definitions"
           },
           {
-            options: "example3 --cicsplex PLEX1 --scope TESTGRP1 --cicshlq CICSTS55.CICS720 " +
-                     "--cpsmhlq CICSTS55.CPSM550 --targetdir /var/cicsts/bundles",
+            options: "example3 --cicsplex PLEX1 --scope TESTGRP1 --cics-hlq CICSTS55.CICS720 " +
+                     "--cpsm-hlq CICSTS55.CPSM550 --target-directory /var/cicsts/bundles",
             description: "Create a cics-deploy profile called 'example3' to connect to the same CPSM managed group of regions, " +
                          "and identify the default USS directory to which bundles should be uploaded"
           }

--- a/src/imperative.ts
+++ b/src/imperative.ts
@@ -32,7 +32,7 @@ const config: IImperativeConfig = {
           title: "The cics-deploy-profile schema",
           description: "Specifies the target environment for the cics-deploy deploy and undeploy actions.",
           properties: {
-            cicsplex: {
+            "cicsplex": {
               optionDefinition: {
                 description: "Specifies the CICSplex (up to 8 characters) to target.",
                 type: "string",
@@ -43,7 +43,7 @@ const config: IImperativeConfig = {
               },
               type: "string"
             },
-            scope: {
+            "scope": {
               optionDefinition: {
                 description: "Specifies the name of the CICS System, or CICS System Group " +
                              "(up to 8 characters) to target.",
@@ -55,7 +55,7 @@ const config: IImperativeConfig = {
               },
               type: "string"
             },
-            csdgroup: {
+            "csd-group": {
               optionDefinition: {
                 description: "Specifies the CSD group (up to 8 characters) for the bundle resource. If a bundle is " +
                              "deployed then a definition is added to this group; if a bundle is undeployed then the " +
@@ -69,7 +69,7 @@ const config: IImperativeConfig = {
               },
               type: "string"
             },
-            resgroup: {
+            "res-group": {
               optionDefinition: {
                 description: "Specifies the BAS resource group (up to 8 characters) for the bundle resource. If a bundle is " +
                              "deployed then a resource is defined in the BAS data repository; if a bundle is undeployed then the " +
@@ -78,11 +78,11 @@ const config: IImperativeConfig = {
                 name: "res-group",
                 aliases: ["rg", "resgroup"],
                 stringLengthRange: [1, MAX_LENGTH],
-                conflictsWith: [ "csdgroup" ],
+                conflictsWith: [ "csd-group" ],
               },
               type: "string"
             },
-            cicshlq: {
+            "cics-hlq": {
               optionDefinition: {
                 description: "Specifies the High Level Qualifier (up to 35 characters) at which the CICS " +
                              "datasets can be found in the target environment.",
@@ -94,7 +94,7 @@ const config: IImperativeConfig = {
               },
               type: "string"
             },
-            cpsmhlq: {
+            "cpsm-hlq": {
               optionDefinition: {
                 description: "Specifies the High Level Qualifier (up to 35 characters) at which the CPSM " +
                              "datasets can be found in the target environment.",
@@ -106,7 +106,7 @@ const config: IImperativeConfig = {
               },
               type: "string"
             },
-            targetdir: {
+            "target-directory": {
               optionDefinition: {
                 description: "Specifies the target zFS location to which CICS bundles should be uploaded (up to 255 characters).",
                 type: "string",
@@ -117,7 +117,7 @@ const config: IImperativeConfig = {
               },
               type: "string"
             },
-            jobcard: {
+            "job-card": {
               optionDefinition: {
                 description: "Specifies the job card to use with any generated DFHDPLOY JCL.",
                 type: "string",
@@ -129,7 +129,7 @@ const config: IImperativeConfig = {
               type: "string"
             }
           },
-          required: ["cicsplex", "scope", "cicshlq", "cpsmhlq", "jobcard"]
+          required: ["cicsplex", "scope", "cics-hlq", "cpsm-hlq", "job-card"]
         },
         createProfileExamples: [
           {


### PR DESCRIPTION
There are loads of name changes for parameters in here, the result should match the discussion in issue #57, which is in turn part of the conformance work in issue #122.

The changes are implemented so that the old names remain as aliases, that keeps the impact on the tests minimal and existing cics-deploy-profiles will continue to work unchanged.

I note that some unrelated changes appear in the generated docs, I guess they were introduced in a different pull request. I presume a build wasn't run at that time, and so those changes are only being seen now.