### PR TITLE
Move --scope summary to be issued for any Bundle

### DIFF
--- a/__tests__/api/BundlePush/BundlePusher.test.ts
+++ b/__tests__/api/BundlePush/BundlePusher.test.ts
@@ -1113,7 +1113,7 @@ describe("BundlePusher01", () => {
         cicsProfile = { host: "wibble", user: "user", password: "thisIsntReal" };
         submitSpy = jest.spyOn(SubmitJobs, "submitJclString").mockImplementation(() =>
                   [{ddName: "SYSTSPRT", stepName: "DFHDPLOY", data: "DFHRL2055I  http://www.ibm.com/xmlns/prod/cics/bundle/NODEJSAPP"}] );
-        cmciSpy.mockImplementation((cicsSession: any, nodejsData: cmci.IResourceParms) => {
+        cmciSpy.mockImplementation((cicsSession: any, regionData: cmci.IResourceParms) => {
           if (nodejsData.name === "CICSRegion") {
             return { response: {
                 records: {

--- a/__tests__/api/BundlePush/BundlePusher.test.ts
+++ b/__tests__/api/BundlePush/BundlePusher.test.ts
@@ -1114,7 +1114,7 @@ describe("BundlePusher01", () => {
         submitSpy = jest.spyOn(SubmitJobs, "submitJclString").mockImplementation(() =>
                   [{ddName: "SYSTSPRT", stepName: "DFHDPLOY", data: "DFHRL2055I  http://www.ibm.com/xmlns/prod/cics/bundle/NODEJSAPP"}] );
         cmciSpy.mockImplementation((cicsSession: any, regionData: cmci.IResourceParms) => {
-          if (nodejsData.name === "CICSRegion") {
+          if (regionData.name === "CICSRegion") {
             return { response: {
                 records: {
                   cicsregion: {

--- a/__tests__/api/BundlePush/BundlePusher.test.ts
+++ b/__tests__/api/BundlePush/BundlePusher.test.ts
@@ -1043,7 +1043,7 @@ describe("BundlePusher01", () => {
         zosmfProfile = { host: "wibble", user: "user" };
         sshProfile = { host: "wibble", user: "user" };
         cicsProfile = { host: "wibble", user: "user", password: "thisIsntReal", cicsPlex: "12345678" };
-        cmciSpy.mockImplementation((cicsSession: any, nodejsData: cmci.IResourceParms) => {
+        cmciSpy.mockImplementation((cicsSession: any, regionData: cmci.IResourceParms) => {
           if (nodejsData.name === "CICSRegion") {
             return { response: {
                 records: {

--- a/__tests__/api/BundlePush/BundlePusher.test.ts
+++ b/__tests__/api/BundlePush/BundlePusher.test.ts
@@ -1044,7 +1044,7 @@ describe("BundlePusher01", () => {
         sshProfile = { host: "wibble", user: "user" };
         cicsProfile = { host: "wibble", user: "user", password: "thisIsntReal", cicsPlex: "12345678" };
         cmciSpy.mockImplementation((cicsSession: any, regionData: cmci.IResourceParms) => {
-          if (nodejsData.name === "CICSRegion") {
+          if (regionData.name === "CICSRegion") {
             return { response: {
                 records: {
                   cicsregion: {

--- a/src/api/BundlePush/BundlePusher.ts
+++ b/src/api/BundlePush/BundlePusher.ts
@@ -700,7 +700,6 @@ export class BundlePusher {
   }
 
   private async gatherNodejsDiagnosticsFromCics(cicsSession: AbstractSession): Promise<boolean> {
-    // Issue a CMCI get to the target CICSplex
     try {
       // Process each NODEJSAPP in the Scope
       this.updateStatus("Querying NODEJSAPP resources over CMCI");


### PR DESCRIPTION
The summary of region information for a given scope is quite useful whether their are NODEJSAPP resources in the bundle or not, so moving it up a level so that it can be issued for any Bundle.