### PR TITLE
Change XML parser dependency

### DIFF
--- a/__tests__/api/BundleContent/BundleMocked.test.ts
+++ b/__tests__/api/BundleContent/BundleMocked.test.ts
@@ -11,17 +11,13 @@
 
 import { Bundle } from "../../../src/api/BundleContent/Bundle";
 import * as fs from "fs";
-
+import * as parser from "fast-xml-parser";
 
 // Note, the following tests mock the file-system. Snapshot based tests are unlikely to
 // work as the jest implementation will itself need to interact with the filesystem.
 describe("MockedFilesystemTests", () => {
     afterEach(() => {
       jest.restoreAllMocks();
-    });
-    beforeAll(() => {
-      // Allow xml2json to initialise itself before we start messing with the filesystem below it.
-      const parser = require("xml2json");
     });
 
     it("should tolerate META-INF directory not existing", () => {
@@ -552,7 +548,7 @@ describe("MockedFilesystemTests", () => {
 
     it("should complain if exceptions are thrown during manifest parsing", () => {
 
-      jest.spyOn(JSON, "parse").mockImplementationOnce(() => { throw new Error("Wibble"); });
+      jest.spyOn(parser, "parse").mockImplementationOnce(() => { throw new Error("Wibble"); });
 
       let err: Error;
       try {

--- a/__tests__/api/BundleContent/Manifest.test.ts
+++ b/__tests__/api/BundleContent/Manifest.test.ts
@@ -169,7 +169,7 @@ describe("Manifest01", () => {
         }
 
         // Check the output as JSON
-        expect(err.message).toContain("Existing CICS Manifest file found with unparsable content.");
+        expect(err.message).toContain("Existing CICS Manifest file found with unparsable content:");
     });
     it("Parse a manifest with bad namespace", () => {
 
@@ -197,6 +197,6 @@ describe("Manifest01", () => {
         }
 
         // Check the output as JSON
-        expect(err.message).toContain("Existing CICS Manifest file found with unparsable content.");
+        expect(err.message).toContain("Existing CICS Manifest file found with unparsable content:");
     });
 });

--- a/__tests__/api/BundleContent/__snapshots__/AutoBundler.test.ts.snap
+++ b/__tests__/api/BundleContent/__snapshots__/AutoBundler.test.ts.snap
@@ -12,17 +12,17 @@ exports[`AutoBundler01 should not merge an existing bundle 1`] = `"{\\"manifest\
 
 exports[`AutoBundler01 should read an existing bundle 1`] = `"{\\"manifest\\":{\\"xmlns\\":\\"http://www.ibm.com/xmlns/prod/cics/bundle\\",\\"bundleVersion\\":\\"1\\",\\"bundleRelease\\":\\"2\\",\\"id\\":\\"ThisIsAnId\\",\\"bundleMajorVer\\":\\"10\\",\\"bundleMinorVer\\":\\"11\\",\\"bundleMicroVer\\":\\"12\\",\\"define\\":[{\\"name\\":\\"name1\\",\\"type\\":\\"type1\\",\\"path\\":\\"path1\\"},{\\"name\\":\\"name2\\",\\"type\\":\\"type2\\",\\"path\\":\\"path2\\"},{\\"name\\":\\"name3\\",\\"type\\":\\"http://www.ibm.com/xmlns/prod/cics/bundle/NODEJSAPP\\",\\"path\\":\\"nodejsapps/Test.nodejsapp\\"}]}}"`;
 
-exports[`AutoBundler01 should receive default values from package.json 1`] = `"{\\"manifest\\":{\\"xmlns\\":\\"http://www.ibm.com/xmlns/prod/cics/bundle\\",\\"$t\\":\\"\\",\\"id\\":\\"testBundleName\\",\\"bundleMajorVer\\":1,\\"bundleMinorVer\\":0,\\"bundleMicroVer\\":0,\\"define\\":[{\\"name\\":\\"testBundleName\\",\\"type\\":\\"http://www.ibm.com/xmlns/prod/cics/bundle/NODEJSAPP\\",\\"path\\":\\"nodejsapps/testBundleName.nodejsapp\\"}]}}"`;
+exports[`AutoBundler01 should receive default values from package.json 1`] = `"{\\"manifest\\":{\\"xmlns\\":\\"http://www.ibm.com/xmlns/prod/cics/bundle\\",\\"id\\":\\"testBundleName\\",\\"bundleMajorVer\\":1,\\"bundleMinorVer\\":0,\\"bundleMicroVer\\":0,\\"define\\":[{\\"name\\":\\"testBundleName\\",\\"type\\":\\"http://www.ibm.com/xmlns/prod/cics/bundle/NODEJSAPP\\",\\"path\\":\\"nodejsapps/testBundleName.nodejsapp\\"}]}}"`;
 
-exports[`AutoBundler01 should set a nodejsapp name 1`] = `"{\\"manifest\\":{\\"xmlns\\":\\"http://www.ibm.com/xmlns/prod/cics/bundle\\",\\"$t\\":\\"\\",\\"id\\":\\"testBundleName\\",\\"bundleMajorVer\\":1,\\"bundleMinorVer\\":0,\\"bundleMicroVer\\":0,\\"define\\":[{\\"name\\":\\"MyExampleOverride\\",\\"type\\":\\"http://www.ibm.com/xmlns/prod/cics/bundle/NODEJSAPP\\",\\"path\\":\\"nodejsapps/MyExampleOverride.nodejsapp\\"}]}}"`;
+exports[`AutoBundler01 should set a nodejsapp name 1`] = `"{\\"manifest\\":{\\"xmlns\\":\\"http://www.ibm.com/xmlns/prod/cics/bundle\\",\\"id\\":\\"testBundleName\\",\\"bundleMajorVer\\":1,\\"bundleMinorVer\\":0,\\"bundleMicroVer\\":0,\\"define\\":[{\\"name\\":\\"MyExampleOverride\\",\\"type\\":\\"http://www.ibm.com/xmlns/prod/cics/bundle/NODEJSAPP\\",\\"path\\":\\"nodejsapps/MyExampleOverride.nodejsapp\\"}]}}"`;
 
 exports[`AutoBundler01 should set a port number 1`] = `"Supplied Port is outside the range of 1-65535: -27"`;
 
-exports[`AutoBundler01 should set the bundle version 1`] = `"{\\"manifest\\":{\\"xmlns\\":\\"http://www.ibm.com/xmlns/prod/cics/bundle\\",\\"$t\\":\\"\\",\\"bundleMajorVer\\":3,\\"bundleMinorVer\\":4,\\"bundleMicroVer\\":5}}"`;
+exports[`AutoBundler01 should set the bundle version 1`] = `"{\\"manifest\\":{\\"xmlns\\":\\"http://www.ibm.com/xmlns/prod/cics/bundle\\",\\"bundleMajorVer\\":3,\\"bundleMinorVer\\":4,\\"bundleMicroVer\\":5}}"`;
 
-exports[`AutoBundler01 should set the bundleid 1`] = `"{\\"manifest\\":{\\"xmlns\\":\\"http://www.ibm.com/xmlns/prod/cics/bundle\\",\\"$t\\":\\"\\",\\"id\\":\\"test\\"}}"`;
+exports[`AutoBundler01 should set the bundleid 1`] = `"{\\"manifest\\":{\\"xmlns\\":\\"http://www.ibm.com/xmlns/prod/cics/bundle\\",\\"id\\":\\"test\\"}}"`;
 
-exports[`AutoBundler01 should support main script from package.json 1`] = `"{\\"manifest\\":{\\"xmlns\\":\\"http://www.ibm.com/xmlns/prod/cics/bundle\\",\\"$t\\":\\"\\",\\"id\\":\\"testBundleName\\",\\"bundleMajorVer\\":1,\\"bundleMinorVer\\":0,\\"bundleMicroVer\\":0,\\"define\\":[{\\"name\\":\\"testBundleName\\",\\"type\\":\\"http://www.ibm.com/xmlns/prod/cics/bundle/NODEJSAPP\\",\\"path\\":\\"nodejsapps/testBundleName.nodejsapp\\"}]}}"`;
+exports[`AutoBundler01 should support main script from package.json 1`] = `"{\\"manifest\\":{\\"xmlns\\":\\"http://www.ibm.com/xmlns/prod/cics/bundle\\",\\"id\\":\\"testBundleName\\",\\"bundleMajorVer\\":1,\\"bundleMinorVer\\":0,\\"bundleMicroVer\\":0,\\"define\\":[{\\"name\\":\\"testBundleName\\",\\"type\\":\\"http://www.ibm.com/xmlns/prod/cics/bundle/NODEJSAPP\\",\\"path\\":\\"nodejsapps/testBundleName.nodejsapp\\"}]}}"`;
 
 exports[`AutoBundler01 should tolerate an almost empty package.json 1`] = `"No startscript value set for NODEJSAPP \\"almostEmpty\\""`;
 

--- a/__tests__/api/BundleContent/__snapshots__/BundleSimple.test.ts.snap
+++ b/__tests__/api/BundleContent/__snapshots__/BundleSimple.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Bundle01 add a NODEJSAPP 1`] = `"{\\"manifest\\":{\\"xmlns\\":\\"http://www.ibm.com/xmlns/prod/cics/bundle\\",\\"$t\\":\\"\\",\\"define\\":[{\\"name\\":\\"NodeName\\",\\"type\\":\\"http://www.ibm.com/xmlns/prod/cics/bundle/NODEJSAPP\\",\\"path\\":\\"nodejsapps/NodeName.nodejsapp\\"}]}}"`;
+exports[`Bundle01 add a NODEJSAPP 1`] = `"{\\"manifest\\":{\\"xmlns\\":\\"http://www.ibm.com/xmlns/prod/cics/bundle\\",\\"define\\":[{\\"name\\":\\"NodeName\\",\\"type\\":\\"http://www.ibm.com/xmlns/prod/cics/bundle/NODEJSAPP\\",\\"path\\":\\"nodejsapps/NodeName.nodejsapp\\"}]}}"`;
 
 exports[`Bundle01 add a NODEJSAPP 2`] = `
 "<manifest xmlns=\\"http://www.ibm.com/xmlns/prod/cics/bundle\\"><define name=\\"NodeName\\" type=\\"http://www.ibm.com/xmlns/prod/cics/bundle/NODEJSAPP\\" path=\\"nodejsapps/NodeName.nodejsapp\\"></define></manifest>
@@ -25,4 +25,4 @@ exports[`Bundle01 should read an existing bundle 1`] = `"{\\"manifest\\":{\\"xml
 
 exports[`Bundle01 should warn that an existing bundle cant be overwritten 1`] = `"A bundle manifest file already exists. Specify --overwrite to replace it, or --merge to merge changes into it."`;
 
-exports[`Bundle01 tolerate an existing almost empty manifest 1`] = `"{\\"manifest\\":{\\"xmlns\\":\\"http://www.ibm.com/xmlns/prod/cics/bundle\\",\\"$t\\":\\"\\",\\"define\\":[{\\"name\\":\\"name1\\",\\"type\\":\\"type1\\",\\"path\\":\\"Artefact1\\"}]}}"`;
+exports[`Bundle01 tolerate an existing almost empty manifest 1`] = `"{\\"manifest\\":{\\"xmlns\\":\\"http://www.ibm.com/xmlns/prod/cics/bundle\\",\\"define\\":[{\\"name\\":\\"name1\\",\\"type\\":\\"type1\\",\\"path\\":\\"Artefact1\\"}]}}"`;

--- a/__tests__/api/BundlePush/BundlePusher.test.ts
+++ b/__tests__/api/BundlePush/BundlePusher.test.ts
@@ -74,9 +74,6 @@ let zosmfProfile = {};
 let sshProfile = {};
 let cicsProfile = {};
 
-// Initialise xml2json before mocking anything
-const parser = require("xml2json");
-
 let zosMFSpy = jest.spyOn(ZosmfSession, "createBasicZosmfSession").mockImplementation(() => ({}));
 let sshSpy = jest.spyOn(SshSession, "createBasicSshSession").mockImplementation(() => ({}));
 let createSpy = jest.spyOn(Create, "uss").mockImplementation(() => ({}));

--- a/__tests__/api/BundlePush/BundlePusher.test.ts
+++ b/__tests__/api/BundlePush/BundlePusher.test.ts
@@ -182,7 +182,7 @@ describe("BundlePusher01", () => {
         existsSpy.mockReturnValue(true);
         readSpy.mockImplementation((data: string) => ("wibble"));
         await runPushTestWithError("__tests__/__resources__/BadManifestBundle01", false,
-                                   "Existing CICS Manifest file found with unparsable content.");
+                                   "Existing CICS Manifest file found with unparsable content:");
     });
     it("should complain with missing manifest file", async () => {
         readSpy.mockImplementationOnce(() => {

--- a/package.json
+++ b/package.json
@@ -31,13 +31,12 @@
     "configurationModule": "lib/imperative.js"
   },
   "dependencies": {
-    "xml2json": "^0.11.2",
+    "fast-xml-parser": "^3.12.16",
     "@zowe/cics": "^2.0.1"
   },
   "devDependencies": {
     "@zowe/cli": "^5.5.0",
     "@zowe/imperative": "^4.1.2",
-    "@zowe/cics": "^2.0.1",
     "@types/fs-extra": "^5.0.5",
     "@types/jest": "^22.2.3",
     "@types/node": "^8.0.28",

--- a/src/api/BundleContent/NodejsappBundlePart.ts
+++ b/src/api/BundleContent/NodejsappBundlePart.ts
@@ -14,6 +14,9 @@
 import { BundlePart } from "./BundlePart";
 import { TemplateNodejsappProfile } from "./TemplateNodejsappProfile";
 import { IHandlerParameters } from "@zowe/imperative";
+import * as parser from "fast-xml-parser";
+
+const serialiser = new parser.j2xParser({ignoreAttributes: false, attributeNamePrefix: ""});
 
 /**
  * Interface to represent the manifest data for a NODEJSAPP BundlePart.
@@ -132,8 +135,7 @@ export class NodejsappBundlePart extends BundlePart {
    * @memberof NodejsappBundlePart
    */
   public getPartXML(): string {
-    const parser = require("xml2json");
-    return parser.toXml(JSON.stringify(this.partXML)) + "\n";
+    return serialiser.parse(this.partXML) + "\n";
   }
 
   /**


### PR DESCRIPTION
Switching to fast-xml-parser which is preferred to xml2json because: 
- it doesn't have any out-of-date dependencies
- it's more actively maintained
- it's pure JS so no need for our users to compile native dependencies. 

Unfortunately I wasn't able to persuade it to tolerate XML namespace prefixes properly, but that's the same as we have today with xm2json. 
