### PR TITLE
Suppress Node.js diagnostics when the bundle didn't install

### DIFF
--- a/__tests__/api/BundlePush/BundlePusher.test.ts
+++ b/__tests__/api/BundlePush/BundlePusher.test.ts
@@ -1141,7 +1141,7 @@ describe("BundlePusher01", () => {
     it("should generate diagnostics even if deploy fails", async () => {
         cicsProfile = { host: "wibble", user: "user", password: "thisIsntReal" };
         submitSpy = jest.spyOn(SubmitJobs, "submitJclString").mockImplementation(() =>
-                  [{ddName: "SYSTSPRT", stepName: "DFHDPLOY", data: "DFHRL2055I"}] );
+                  [{ddName: "SYSTSPRT", stepName: "DFHDPLOY", data: "DFHRL2055I DFHRL2067W"}] );
         readSpy = jest.spyOn(fs, "readFileSync").mockImplementation((data: string) => {
           if (data.indexOf("cics.xml") > -1) {
             return "<manifest xmlns=\"http://www.ibm.com/xmlns/prod/cics/bundle\">" +
@@ -1491,6 +1491,56 @@ describe("BundlePusher01", () => {
         expect(readSpy).toHaveBeenCalledTimes(1);
         expect(uploadSpy).toHaveBeenCalledTimes(1);
         expect(cmciSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("should not attempt to generate diagnostics for NODEJSAPPs if bundle does not install", async () => {
+        readSpy = jest.spyOn(fs, "readFileSync").mockImplementation((data: string) => {
+            if (data.indexOf("cics.xml") > -1) {
+              return "<manifest xmlns=\"http://www.ibm.com/xmlns/prod/cics/bundle\">" +
+                     "<define name=\"test\" type=\"http://www.ibm.com/xmlns/prod/cics/bundle/NODEJSAPP\" path=\"nodejsapps/test.nodejsapp\"></define>" +
+                     "</manifest>";
+            }
+          });
+        submitSpy = jest.spyOn(SubmitJobs, "submitJclString").mockImplementation(() =>
+                  [{ddName: "SYSTSPRT", stepName: "DFHDPLOY", data: "DFHRL2055I"}] );
+        cicsProfile = { host: "wibble", user: "user", password: "thisIsntReal", cicsPlex: "12345678", regionName: "12345678" };
+        cmciSpy.mockImplementation((cicsSession: any, nodejsData: cmci.IResourceParms) => {
+            if (nodejsData.name === "CICSRegion") {
+                return { response: {
+                    records: {
+                    cicsregion: {
+                        applid: "ABCDEFG", jobid: "JOB12345", jobname: "MYCICS"
+                    }
+                    }
+                }
+                };
+            } else if (nodejsData.name === "CICSNodejsapp") {
+                return { response: {
+                    records: {
+                      cicsnodejsapp: [{
+                        name: "name", pid: "22", enablestatus: "ENABLED", stderr: "/tmp/stderr", stdout: "/tmp/stdout", eyu_cicsname: "1"
+                      }]
+                    }
+                  }
+                };
+            } else {
+                return {};
+            }
+        });
+
+        const parms = getCommonParmsForPushTests();
+
+        await runPushTestWithError("__tests__/__resources__/ExampleBundle01", false,
+              "DFHDPLOY stopped processing for jobid UNKNOWN due to an error.", parms);
+
+        expect(consoleText).toContain("Gathering scope information");
+        expect(consoleText).toContain("Querying regions in scope over CMCI");
+        expect(consoleText).not.toContain("Querying NODEJSAPP resources over CMCI");
+        expect(consoleText).not.toContain("zowe cics get resource CICSNodejsapp");
+        expect(consoleText).not.toContain("An attempt to query the remote CICSplex using the cics plug-in has failed");
+        expect(consoleText).toContain("Consider examining the JESMSGLG, MSGUSR, SYSPRINT and SYSOUT spool files for job ID JOB12345 for more information," +
+                                      " or consult your CICS system programmer.");
+        expect(cmciSpy).toHaveBeenCalledTimes(1);
     });
 });
 

--- a/__tests__/api/BundlePush/BundlePusher.test.ts
+++ b/__tests__/api/BundlePush/BundlePusher.test.ts
@@ -1538,8 +1538,7 @@ describe("BundlePusher01", () => {
         expect(consoleText).not.toContain("Querying NODEJSAPP resources over CMCI");
         expect(consoleText).not.toContain("zowe cics get resource CICSNodejsapp");
         expect(consoleText).not.toContain("An attempt to query the remote CICSplex using the cics plug-in has failed");
-        expect(consoleText).toContain("Consider examining the JESMSGLG, MSGUSR, SYSPRINT and SYSOUT spool files for job ID JOB12345 for more information," +
-                                      " or consult your CICS system programmer.");
+        expect(consoleText).toContain("DFHDPLOY output implied the bundle failed to install.");
         expect(cmciSpy).toHaveBeenCalledTimes(1);
     });
 });

--- a/src/api/BundlePush/BundlePusher.ts
+++ b/src/api/BundlePush/BundlePusher.ts
@@ -391,7 +391,14 @@ export class BundlePusher {
 
     // Collect general information about the regions in the CICSplex scope
     let deployMessages = await this.generateGeneralDiagnostics(cicsSession);
-    if (deployMessages !== "" && bundle.containsDefinitionsOfType("http://www.ibm.com/xmlns/prod/cics/bundle/NODEJSAPP")) {
+
+    if (deployError !== undefined && dfhdployOutput.indexOf("DFHRL2067") === -1) {
+        // If we have an, but DFHDPLOY did not report that some bundleparts are disabled,
+        // we can assume bundle didn't install at all. In this case skip generation of
+        // Node.js diagnostics.
+        deployMessages += "Consider examining the JESMSGLG, MSGUSR, SYSPRINT and SYSOUT spool files for job ID JOB12345 for more information, ";
+        deployMessages += "or consult your CICS system programmer.";
+    } else if (deployMessages !== "" && bundle.containsDefinitionsOfType("http://www.ibm.com/xmlns/prod/cics/bundle/NODEJSAPP")) {
       // Generate additional diagnostic output for Node.js
       deployMessages += await this.generateNodejsSpecificDiagnostics(cicsSession);
     }

--- a/src/api/BundlePush/BundlePusher.ts
+++ b/src/api/BundlePush/BundlePusher.ts
@@ -393,11 +393,12 @@ export class BundlePusher {
     let deployMessages = await this.generateGeneralDiagnostics(cicsSession);
 
     if (deployError !== undefined && dfhdployOutput.indexOf("DFHRL2067") === -1) {
-        // If we have an, but DFHDPLOY did not report that some bundleparts are disabled,
+        // If we have an error, but DFHDPLOY did not report that some bundleparts are disabled,
         // we can assume bundle didn't install at all. In this case skip generation of
         // Node.js diagnostics.
-        deployMessages += "Consider examining the JESMSGLG, MSGUSR, SYSPRINT and SYSOUT spool files for job ID JOB12345 for more information, ";
-        deployMessages += "or consult your CICS system programmer.";
+        deployMessages += "DFHDPLOY output implied the bundle failed to install. Check the output above for further information. ";
+        deployMessages += "Consider examining the JESMSGLG, MSGUSR, SYSPRINT and SYSOUT spool files of the CICS region job, ";
+        deployMessages += "or consult your CICS system programmer.\n";
     } else if (deployMessages !== "" && bundle.containsDefinitionsOfType("http://www.ibm.com/xmlns/prod/cics/bundle/NODEJSAPP")) {
       // Generate additional diagnostic output for Node.js
       deployMessages += await this.generateNodejsSpecificDiagnostics(cicsSession);


### PR DESCRIPTION
This should help with #216 