### PR TITLE
Add peerDependency to get rid of zowe warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,9 @@
   },
   "peerDependencies": {
     "@brightside/core": "^2.28.1",
-    "@brightside/imperative": "^2.4.2"
+    "@brightside/imperative": "^2.4.2",
+    "@zowe/cli": "^5.5.0",
+    "@zowe/imperative": "^4.1.2"
   },
   "jest": {
     "modulePathIgnorePatterns": [


### PR DESCRIPTION
Added @zowe/cli and @zowe/imperative in the peerDependency.
It won't install those when "npm install"

This is to get rid of the warning message for "zowe plugins validate zowe-cli-cics-deploy-plugin"