### PR TITLE
Added mustache in devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "configurationModule": "lib/imperative.js"
   },
   "dependencies": {
-    "fast-xml-parser": "^3.12.16",
-    "@brightside/cics": "^1.1.1"
+    "@brightside/cics": "^1.1.1",
+    "fast-xml-parser": "^3.12.16"
   },
   "devDependencies": {
     "@brightside/core": "^2.28.1",
@@ -58,6 +58,7 @@
     "jest-junit": "^6.3.0",
     "jest-stare": "^1.11.1",
     "js-yaml": "^3.13.0",
+    "mustache": "^3.0.1",
     "rimraf": "^2.6.2",
     "ts-jest": "^24.0.0",
     "ts-node": "^3.3.0",


### PR DESCRIPTION
We get an error message when running `npm run build`, saying:
```
Error: Cannot find module 'mustache'
```

I've added `mustache` on the devDependency in package.json.