### PR TITLE
Changed the installation guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,6 +93,14 @@ To save you having to type the above for every commit, Git can add the `Signed-o
 
 If you haven't signed each commit, then the pull request will fail to pass all checks.
 
+### Build and install the cics-deploy plugin
+```console
+git clone https://github.com/IBM/zowe-cli-cics-deploy-plugin
+cd zowe-cli-cics-deploy-plugin
+npm install
+npm run build
+zowe plugins install .
+```
 
 ## Developing Zowe CLI plug-ins
 

--- a/docs/pages/cdp/cdp-Installing.md
+++ b/docs/pages/cdp/cdp-Installing.md
@@ -24,12 +24,21 @@ toc: false
     sudo npm install -g @brightside/core
     ```
 
-3. Build and install the cics-deploy plug-in as described in [Setting up your development environment](https://github.com/IBM/zowe-cli-cics-deploy-plugin/blob/master/docs-internal/tutorials/Setup.md). For example:
+3. Install the cics plugin:
 
     ```console
-    mkdir ~/cics-deploy
-    cd ~/cics-deploy
-    rm -Rf *
+    zowe plugins install @brightside/cics
+    ```
+
+4. Install the cics-deploy plugin:
+
+    ```console
+    zowe plugins install zowe-cli-cics-deploy-plugin
+    ```
+
+    Alternatively, you can build and install the cics-deploy plugin from the source. For example:
+
+    ```console
     git clone https://github.com/IBM/zowe-cli-cics-deploy-plugin
     cd zowe-cli-cics-deploy-plugin
     npm install
@@ -37,27 +46,16 @@ toc: false
     zowe plugins install .
     ```
 
-4. Install the cics plugin:
+5. Validate the plug-ins are installed:
 
     ```console
-    zowe plugins install @brightside/cics
+    zowe plugins validate
     ```
 
-5. Verify the plug-ins are installed:
+    validates the installed plugins:
 
-    ```console
-    zowe plugins list
-    ```
-
-    Displays a list of the installed plug-ins:
-
-   <pre class="messageText">
-   -- pluginName: zowe-cli-cics-deploy-plugin
-   -- package: zowe-cli-cics-deploy-plugin
-   -- version: 0.5.0
-   -- registry: https://eu.artifactory.swg-devops.com/artifactory/api/npm/cicsts-npm-virtual
-
-   -- pluginName: @zowe/cics
-   -- package: @zowe/cics
-   -- version: 2.0.1
-   -- registry: https://eu.artifactory.swg-devops.com/artifactory/api/npm/cicsts-npm-virtual</pre>
+    <pre class="messageText">
+    _____ Validation results for plugin '@brightside/cics' _____
+    This plugin was successfully validated. Enjoy the plugin. <br>
+    _____ Validation results for plugin 'zowe-cli-cics-deploy-plugin' _____
+    This plugin was successfully validated. Enjoy the plugin. </pre>

--- a/docs/pages/cdp/cdp-Installing.md
+++ b/docs/pages/cdp/cdp-Installing.md
@@ -36,16 +36,6 @@ toc: false
     zowe plugins install zowe-cli-cics-deploy-plugin
     ```
 
-    Alternatively, you can build and install the cics-deploy plugin from the source. For example:
-
-    ```console
-    git clone https://github.com/IBM/zowe-cli-cics-deploy-plugin
-    cd zowe-cli-cics-deploy-plugin
-    npm install
-    npm run build
-    zowe plugins install .
-    ```
-
 5. Validate the plug-ins are installed:
 
     ```console

--- a/docs/pages/cdp/cdp-Installing.md
+++ b/docs/pages/cdp/cdp-Installing.md
@@ -21,13 +21,13 @@ toc: false
 2. Install [Zowe CLI](https://zowe.github.io/docs-site/latest/user-guide/cli-installcli.html). For example, to install using npm:
 
     ```console
-    sudo npm install -g @brightside/core
+    npm install -g @brightside/core
     ```
 
 3. Install the cics plugin:
 
     ```console
-    zowe plugins install @brightside/cics
+    zowe plugins install @brightside/cics@lts-incremental
     ```
 
 4. Install the cics-deploy plugin:
@@ -36,16 +36,22 @@ toc: false
     zowe plugins install zowe-cli-cics-deploy-plugin
     ```
 
-5. Validate the plug-ins are installed:
+5. Verify the plug-ins are installed:
 
     ```console
-    zowe plugins validate
+    zowe plugins list
     ```
 
-    validates the installed plugins:
+    Displays a list of the installed plugins:
 
     <pre class="messageText">
-    _____ Validation results for plugin '@brightside/cics' _____
-    This plugin was successfully validated. Enjoy the plugin. <br>
-    _____ Validation results for plugin 'zowe-cli-cics-deploy-plugin' _____
-    This plugin was successfully validated. Enjoy the plugin. </pre>
+    Installed plugins:
+
+    -- pluginName: @brightside/cics
+    -- package: @brightside/cics@lts-incremental
+    -- version: 1.1.1
+    -- registry: https://registry.npmjs.org/<br>
+    -- pluginName: zowe-cli-cics-deploy-plugin
+    -- package: zowe-cli-cics-deploy-plugin
+    -- version: 0.5.0
+    -- registry: https://registry.npmjs.org/ </pre>


### PR DESCRIPTION
- Swapped 3 and 4 as cics plugin is pre-requisite for our plugin.
- Added installation command using npmjs.org
- Moved "Build and install from the source" to `CONTRIBUTING.md` as Matthew suggested.
  - Removed `mkdir` and `rm -rf` command in the build from source section because it's not necessary and it might cause to remove unintended files, if the command fails somehow.
- Changed Verification section to use `zowe plugins validate` command.
