### PR TITLE
zowe-dev update

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -84,7 +84,6 @@ def RELEASE_BRANCHES = [MASTER_BRANCH, DEV_BRANCH, ZOWE_DEV_BRANCH]
 */
 def NOTIFY_BRANCHES = [MASTER_BRANCH, DEV_BRANCH, ZOWE_DEV_BRANCH]
 
-
 /**
  * Variables to check any new commit since the previous successful commit
  */

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,14 +70,19 @@ def MASTER_BRANCH = "master"
 def DEV_BRANCH = "dev"
 
 /**
+ * The name of the zowe-dev branch
+ */
+def ZOWE_DEV_BRANCH = "zowe-dev"
+
+/**
  * Release branches
  */
-def RELEASE_BRANCHES = [MASTER_BRANCH, DEV_BRANCH]
+def RELEASE_BRANCHES = [MASTER_BRANCH, DEV_BRANCH, ZOWE_DEV_BRANCH]
 
 /** 
  * Branches to send notifcations for
 */
-def NOTIFY_BRANCHES = [MASTER_BRANCH, DEV_BRANCH]
+def NOTIFY_BRANCHES = [MASTER_BRANCH, DEV_BRANCH, ZOWE_DEV_BRANCH]
 
 
 /**
@@ -95,7 +100,7 @@ def PRODUCT_NAME = "zowe-cli-cics-deploy-plugin"
 /**
  * This is where the Zowe project needs to be installed
  */
-def ZOWE_CLI_INSTALL_DIR = "/.npm-global/lib/node_modules/@brightside/core"
+def ZOWE_CLI_INSTALL_DIR = "/.npm-global/lib/node_modules/@zowe/cli"
 
 def ARTIFACTORY_CREDENTIALS_ID = "c8e3aa62-5eef-4e6b-8a3f-aa1006a7ef01"
 
@@ -200,9 +205,8 @@ pipeline {
                     echo "Install Zowe CLI globaly"
                     sh "rm -f .npmrc"
                     sh "npm set registry https://registry.npmjs.org"
-                    sh "npm set @brightside:registry=https://api.bintray.com/npm/ca/brightside/"
 
-                    sh "npm install -g @brightside/core@lts-incremental"
+                    sh "npm install -g @zowe/cli@daily"
                     sh "zowe --version"
                 }
             }

--- a/__tests__/__src__/environment/TestEnvironment.ts
+++ b/__tests__/__src__/environment/TestEnvironment.ts
@@ -10,7 +10,7 @@
 */
 
 import {ISetupEnvironmentParms} from "./doc/parms/ISetupEnvironmentParms";
-import {ImperativeError, ImperativeExpect, IO, Logger, TextUtils} from "@brightside/imperative";
+import {ImperativeError, ImperativeExpect, IO, Logger, TextUtils} from "@zowe/imperative";
 import * as nodePath from "path";
 import {mkdirpSync} from "fs-extra";
 import {ITestEnvironment} from "./doc/response/ITestEnvironment";

--- a/__tests__/api/BundleContent/AutoBundler.test.ts
+++ b/__tests__/api/BundleContent/AutoBundler.test.ts
@@ -10,7 +10,7 @@
 */
 
 import { AutoBundler } from "../../../src/api/BundleContent/AutoBundler";
-import { IHandlerParameters } from "@brightside/imperative";
+import { IHandlerParameters } from "@zowe/imperative";
 import * as GenerateBundleDefinition from "../../../src/cli/generate/bundle/GenerateBundle.definition";
 import * as fse from "fs-extra";
 

--- a/__tests__/api/BundleDeploy/BundleDeployer.test.ts
+++ b/__tests__/api/BundleDeploy/BundleDeployer.test.ts
@@ -10,9 +10,9 @@
 */
 
 import { BundleDeployer } from "../../../src/api/BundleDeploy/BundleDeployer";
-import { IHandlerParameters, TaskStage } from "@brightside/imperative";
+import { IHandlerParameters, TaskStage } from "@zowe/imperative";
 import * as DeployBundleDefinition from "../../../src/cli/deploy/bundle/DeployBundle.definition";
-import { ZosmfSession, SubmitJobs, List } from "@brightside/core";
+import { ZosmfSession, SubmitJobs, List } from "@zowe/cli";
 
 
 const DEFAULT_PARAMTERS: IHandlerParameters = {

--- a/__tests__/api/BundlePush/BundlePusher.test.ts
+++ b/__tests__/api/BundlePush/BundlePusher.test.ts
@@ -10,12 +10,12 @@
 */
 
 import { BundlePusher } from "../../../src/api/BundlePush/BundlePusher";
-import { IHandlerParameters, ImperativeError, IImperativeError, IProfile, Session } from "@brightside/imperative";
-import * as cmci from "@brightside/cics";
+import { IHandlerParameters, ImperativeError, IImperativeError, IProfile, Session } from "@zowe/imperative";
+import * as cmci from "@zowe/cics";
 import * as PushBundleDefinition from "../../../src/cli/push/bundle/PushBundle.definition";
 import * as fse from "fs-extra";
 import * as fs from "fs";
-import { ZosmfSession, SshSession, SubmitJobs, Shell, List, Upload, Create } from "@brightside/core";
+import { ZosmfSession, SshSession, SubmitJobs, Shell, List, Upload, Create } from "@zowe/cli";
 
 const DEFAULT_PARAMTERS: IHandlerParameters = {
     arguments: {

--- a/__tests__/api/BundlePush/SubtaskWithStatus.test.ts
+++ b/__tests__/api/BundlePush/SubtaskWithStatus.test.ts
@@ -9,7 +9,7 @@
 *
 */
 import { SubtaskWithStatus } from "../../../src/api/BundlePush/SubtaskWithStatus";
-import { TaskStage, ITaskWithStatus, TaskProgress } from "@brightside/imperative";
+import { TaskStage, ITaskWithStatus, TaskProgress } from "@zowe/imperative";
 
 
 let parentTask: ITaskWithStatus;

--- a/__tests__/cli/deploy/Deploy.definition.test.ts
+++ b/__tests__/cli/deploy/Deploy.definition.test.ts
@@ -11,7 +11,7 @@
 */
 
 import * as fs from "fs";
-import { Imperative } from "@brightside/imperative";
+import { Imperative } from "@zowe/imperative";
 
 describe("Deploy definition", () => {
     it("should match the snapshot", () => {

--- a/__tests__/cli/deploy/bundle/DeployBundle.definition.test.ts
+++ b/__tests__/cli/deploy/bundle/DeployBundle.definition.test.ts
@@ -11,7 +11,7 @@
 */
 
 import * as fs from "fs";
-import { Imperative } from "@brightside/imperative";
+import { Imperative } from "@zowe/imperative";
 
 describe("bundle definition", () => {
     it("should match the snapshot", () => {

--- a/__tests__/cli/deploy/bundle/DeployBundle.handler.test.ts
+++ b/__tests__/cli/deploy/bundle/DeployBundle.handler.test.ts
@@ -10,7 +10,7 @@
 *
 */
 
-import {IHandlerParameters, ImperativeError} from "@brightside/imperative";
+import {IHandlerParameters, ImperativeError} from "@zowe/imperative";
 import * as DeployBundleDefinition from "../../../../src/cli/deploy/bundle/DeployBundle.definition";
 import * as DeployBundleHandler from "../../../../src/cli/deploy/bundle/DeployBundle.handler";
 

--- a/__tests__/cli/generate/Generate.definition.test.ts
+++ b/__tests__/cli/generate/Generate.definition.test.ts
@@ -11,7 +11,7 @@
 */
 
 import * as fs from "fs";
-import { Imperative } from "@brightside/imperative";
+import { Imperative } from "@zowe/imperative";
 
 describe("Generate definition", () => {
     it("should match the snapshot", () => {

--- a/__tests__/cli/generate/bundle/GenerateBundle.definition.test.ts
+++ b/__tests__/cli/generate/bundle/GenerateBundle.definition.test.ts
@@ -11,7 +11,7 @@
 */
 
 import * as fs from "fs";
-import { Imperative } from "@brightside/imperative";
+import { Imperative } from "@zowe/imperative";
 
 describe("bundle definition", () => {
     it("should match the snapshot", () => {

--- a/__tests__/cli/generate/bundle/GenerateBundle.handler.test.ts
+++ b/__tests__/cli/generate/bundle/GenerateBundle.handler.test.ts
@@ -10,8 +10,8 @@
 *
 */
 
-import {CheckStatus, ZosmfSession} from "@brightside/core";
-import {IHandlerParameters, Imperative, ImperativeError} from "@brightside/imperative";
+import {CheckStatus, ZosmfSession} from "@zowe/cli";
+import {IHandlerParameters, Imperative, ImperativeError} from "@zowe/imperative";
 import * as GenerateBundleDefinition from "../../../../src/cli/generate/bundle/GenerateBundle.definition";
 import * as GenerateBundleHandler from "../../../../src/cli/generate/bundle/GenerateBundle.handler";
 import * as fs from "fs";

--- a/__tests__/cli/push/Push.definition.test.ts
+++ b/__tests__/cli/push/Push.definition.test.ts
@@ -11,7 +11,7 @@
 */
 
 import * as fs from "fs";
-import { Imperative } from "@brightside/imperative";
+import { Imperative } from "@zowe/imperative";
 
 describe("Push definition", () => {
     it("should match the snapshot", () => {

--- a/__tests__/cli/push/bundle/PushBundle.definition.test.ts
+++ b/__tests__/cli/push/bundle/PushBundle.definition.test.ts
@@ -11,7 +11,7 @@
 */
 
 import * as fs from "fs";
-import { Imperative } from "@brightside/imperative";
+import { Imperative } from "@zowe/imperative";
 
 describe("bundle definition", () => {
     it("should match the snapshot", () => {

--- a/__tests__/cli/push/bundle/PushBundle.handler.test.ts
+++ b/__tests__/cli/push/bundle/PushBundle.handler.test.ts
@@ -10,7 +10,7 @@
 *
 */
 
-import {IHandlerParameters, ImperativeError} from "@brightside/imperative";
+import {IHandlerParameters, ImperativeError} from "@zowe/imperative";
 import * as PushBundleDefinition from "../../../../src/cli/push/bundle/PushBundle.definition";
 import * as PushBundleHandler from "../../../../src/cli/push/bundle/PushBundle.handler";
 

--- a/__tests__/cli/undeploy/Undeploy.definition.test.ts
+++ b/__tests__/cli/undeploy/Undeploy.definition.test.ts
@@ -11,7 +11,7 @@
 */
 
 import * as fs from "fs";
-import { Imperative } from "@brightside/imperative";
+import { Imperative } from "@zowe/imperative";
 
 describe("Undeploy definition", () => {
     it("should match the snapshot", () => {

--- a/__tests__/cli/undeploy/bundle/UndeployBundle.definition.test.ts
+++ b/__tests__/cli/undeploy/bundle/UndeployBundle.definition.test.ts
@@ -11,7 +11,7 @@
 */
 
 import * as fs from "fs";
-import { Imperative } from "@brightside/imperative";
+import { Imperative } from "@zowe/imperative";
 
 describe("bundle definition", () => {
     it("should match the snapshot", () => {

--- a/__tests__/cli/undeploy/bundle/UndeployBundle.handler.test.ts
+++ b/__tests__/cli/undeploy/bundle/UndeployBundle.handler.test.ts
@@ -10,8 +10,8 @@
 *
 */
 
-import {CheckStatus, ZosmfSession} from "@brightside/core";
-import {IHandlerParameters, Imperative, ImperativeError} from "@brightside/imperative";
+import {CheckStatus, ZosmfSession} from "@zowe/cli";
+import {IHandlerParameters, Imperative, ImperativeError} from "@zowe/imperative";
 import * as UndeployBundleDefinition from "../../../../src/cli/undeploy/bundle/UndeployBundle.definition";
 import * as UndeployBundleHandler from "../../../../src/cli/undeploy/bundle/UndeployBundle.handler";
 import * as fs from "fs";

--- a/gulp/GenerateDoc.ts
+++ b/gulp/GenerateDoc.ts
@@ -12,7 +12,7 @@
 
 import { ITaskFunction } from "./GulpHelpers";
 import * as util from "util";
-import { DefaultHelpGenerator, Imperative, ImperativeConfig, ICommandDefinition } from "@brightside/imperative";
+import { DefaultHelpGenerator, Imperative, ImperativeConfig, ICommandDefinition } from "@zowe/imperative";
 
 const gutil = require("gulp-util");
 const fs = require("fs");

--- a/package.json
+++ b/package.json
@@ -31,12 +31,12 @@
     "configurationModule": "lib/imperative.js"
   },
   "dependencies": {
-    "@brightside/cics": "^1.1.1",
+    "@zowe/cics": "^2.0.1",
     "fast-xml-parser": "^3.12.16"
   },
   "devDependencies": {
-    "@brightside/core": "^2.28.1",
-    "@brightside/imperative": "^2.4.2",
+    "@zowe/cli": "^5.9.1",
+    "@zowe/imperative": "^4.1.8",
     "@types/fs-extra": "^5.0.5",
     "@types/jest": "^22.2.3",
     "@types/node": "^8.0.28",
@@ -68,8 +68,8 @@
     "uuid": "^3.3.2"
   },
   "peerDependencies": {
-    "@brightside/core": "^2.28.1",
-    "@brightside/imperative": "^2.4.2"
+    "@zowe/cli": "^5.9.1",
+    "@zowe/imperative": "^4.1.8"
   },
   "jest": {
     "modulePathIgnorePatterns": [

--- a/scripts/unlinkImperative.js
+++ b/scripts/unlinkImperative.js
@@ -17,7 +17,7 @@ const fs = require("fs");
 
 const ok = 0;
 const error = 1;
-const impSymLinkPath = "./node_modules/@brightside/imperative";
+const impSymLinkPath = "./node_modules/@zowe/imperative";
 
 if (fs.existsSync(impSymLinkPath)) {
     // Get the file status to determine if it is a symlink.

--- a/src/api/BundleContent/AutoBundler.ts
+++ b/src/api/BundleContent/AutoBundler.ts
@@ -12,7 +12,7 @@
 "use strict";
 
 import { Bundle } from "./Bundle";
-import { Logger, IHandlerParameters } from "@brightside/imperative";
+import { Logger, IHandlerParameters } from "@zowe/imperative";
 
 
 /**

--- a/src/api/BundleContent/Bundle.ts
+++ b/src/api/BundleContent/Bundle.ts
@@ -14,7 +14,7 @@
 import { Manifest } from "./Manifest";
 import { BundlePart, IBundlePartDataType } from "./BundlePart";
 import { NodejsappBundlePart } from "./NodejsappBundlePart";
-import { IHandlerParameters } from "@brightside/imperative";
+import { IHandlerParameters } from "@zowe/imperative";
 
 /**
  * Class to represent a CICS Bundle.

--- a/src/api/BundleContent/BundlePart.ts
+++ b/src/api/BundleContent/BundlePart.ts
@@ -12,7 +12,7 @@
 "use strict";
 
 import { Manifest } from "./Manifest";
-import { IHandlerParameters } from "@brightside/imperative";
+import { IHandlerParameters } from "@zowe/imperative";
 
 /**
  * Interface to represent the manifest data for a BundlePart.

--- a/src/api/BundleContent/Manifest.ts
+++ b/src/api/BundleContent/Manifest.ts
@@ -12,7 +12,7 @@
 "use strict";
 
 import { BundlePart, IBundlePartDataType } from "./BundlePart";
-import { IHandlerParameters } from "@brightside/imperative";
+import { IHandlerParameters } from "@zowe/imperative";
 
 import * as parser from "fast-xml-parser";
 

--- a/src/api/BundleContent/NodejsappBundlePart.ts
+++ b/src/api/BundleContent/NodejsappBundlePart.ts
@@ -13,7 +13,7 @@
 
 import { BundlePart } from "./BundlePart";
 import { TemplateNodejsappProfile } from "./TemplateNodejsappProfile";
-import { IHandlerParameters } from "@brightside/imperative";
+import { IHandlerParameters } from "@zowe/imperative";
 import * as parser from "fast-xml-parser";
 
 const serialiser = new parser.j2xParser({ignoreAttributes: false, attributeNamePrefix: ""});

--- a/src/api/BundleDeploy/BundleDeployer.ts
+++ b/src/api/BundleDeploy/BundleDeployer.ts
@@ -12,8 +12,8 @@
 "use strict";
 
 import { IHandlerParameters, Logger, ImperativeError, AbstractSession, ITaskWithStatus,
-         TaskStage , TaskProgress} from "@brightside/imperative";
-import { ZosmfSession, SubmitJobs, List } from "@brightside/core";
+         TaskStage , TaskProgress} from "@zowe/imperative";
+import { ZosmfSession, SubmitJobs, List } from "@zowe/cli";
 import { ParmValidator } from "./ParmValidator";
 import * as path from "path";
 import { ZosmfConfig } from "../BundlePush/ZosmfConfig";

--- a/src/api/BundleDeploy/ParmValidator.ts
+++ b/src/api/BundleDeploy/ParmValidator.ts
@@ -11,7 +11,7 @@
 
 "use strict";
 
-import { IHandlerParameters, Logger } from "@brightside/imperative";
+import { IHandlerParameters, Logger } from "@zowe/imperative";
 
 export class ParmValidator {
 

--- a/src/api/BundlePush/BundlePusher.ts
+++ b/src/api/BundlePush/BundlePusher.ts
@@ -11,9 +11,9 @@
 
 "use strict";
 
-import { IHandlerParameters, AbstractSession, ITaskWithStatus, TaskStage, TaskProgress, Logger, IProfile, Session } from "@brightside/imperative";
-import { List, ZosmfSession, SshSession, Shell, Upload, IUploadOptions, ZosFilesAttributes, Create } from "@brightside/core";
-import { getResource, IResourceParms } from "@brightside/cics";
+import { IHandlerParameters, AbstractSession, ITaskWithStatus, TaskStage, TaskProgress, Logger, IProfile, Session } from "@zowe/imperative";
+import { List, ZosmfSession, SshSession, Shell, Upload, IUploadOptions, ZosFilesAttributes, Create } from "@zowe/cli";
+import { getResource, IResourceParms } from "@zowe/cics";
 import { BundleDeployer } from "../BundleDeploy/BundleDeployer";
 import { Bundle } from "../BundleContent/Bundle";
 import { SubtaskWithStatus } from "./SubtaskWithStatus";
@@ -305,7 +305,7 @@ export class BundlePusher {
       return undefined;
     }
 
-    // At time of writing, the CicsSession object in the @brightside/cics project isn't
+    // At time of writing, the CicsSession object in the @zowe/cics project isn't
     // accessible, so the following code is copied out of CicsSession.createBasicCicsSession().
     try {
       return new Session({

--- a/src/api/BundlePush/CmciConfig.ts
+++ b/src/api/BundlePush/CmciConfig.ts
@@ -11,7 +11,7 @@
 
 "use strict";
 
-import { IHandlerParameters, IProfile } from "@brightside/imperative";
+import { IHandlerParameters, IProfile } from "@zowe/imperative";
 
 
 /**

--- a/src/api/BundlePush/SshConfig.ts
+++ b/src/api/BundlePush/SshConfig.ts
@@ -11,7 +11,7 @@
 
 "use strict";
 
-import { IHandlerParameters, IProfile } from "@brightside/imperative";
+import { IHandlerParameters, IProfile } from "@zowe/imperative";
 
 
 /**

--- a/src/api/BundlePush/SubtaskWithStatus.ts
+++ b/src/api/BundlePush/SubtaskWithStatus.ts
@@ -8,7 +8,7 @@
 * Copyright IBM Corp, 2019
 *
 */
-import { ITaskWithStatus, TaskProgress, TaskStage, ImperativeExpect, ImperativeError, Logger} from "@brightside/imperative";
+import { ITaskWithStatus, TaskProgress, TaskStage, ImperativeExpect, ImperativeError, Logger} from "@zowe/imperative";
 
 
 export class SubtaskWithStatus {

--- a/src/api/BundlePush/ZosmfConfig.ts
+++ b/src/api/BundlePush/ZosmfConfig.ts
@@ -11,7 +11,7 @@
 
 "use strict";
 
-import { IHandlerParameters, IProfile } from "@brightside/imperative";
+import { IHandlerParameters, IProfile } from "@zowe/imperative";
 
 
 /**

--- a/src/cli/deploy/Deploy.definition.ts
+++ b/src/cli/deploy/Deploy.definition.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { ICommandDefinition } from "@brightside/imperative";
+import { ICommandDefinition } from "@zowe/imperative";
 import { DeployBundleDefinition } from "./bundle/DeployBundle.definition";
 /**
  * Imperative command to "deploy" a Bundle, etc.

--- a/src/cli/deploy/bundle/DeployBundle.definition.ts
+++ b/src/cli/deploy/bundle/DeployBundle.definition.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { ICommandDefinition } from "@brightside/imperative";
+import { ICommandDefinition } from "@zowe/imperative";
 import { NameOption } from "../../shared/Name.option";
 import { BundledirOption } from "./options/Bundledir.option";
 import { CicsplexOption } from "../../shared/Cicsplex.option";

--- a/src/cli/deploy/bundle/DeployBundle.handler.ts
+++ b/src/cli/deploy/bundle/DeployBundle.handler.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { ICommandHandler, IHandlerParameters } from "@brightside/imperative";
+import { ICommandHandler, IHandlerParameters } from "@zowe/imperative";
 import { BundleParentHandler } from "../../shared/BundleParent.handler";
 import { BundleDeployer } from "../../../api/BundleDeploy/BundleDeployer";
 

--- a/src/cli/deploy/bundle/options/Bundledir.option.ts
+++ b/src/cli/deploy/bundle/options/Bundledir.option.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { ICommandOptionDefinition } from "@brightside/imperative";
+import { ICommandOptionDefinition } from "@zowe/imperative";
 
 const MAX_LENGTH = 255;
 

--- a/src/cli/deploy/bundle/options/Description.option.ts
+++ b/src/cli/deploy/bundle/options/Description.option.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { ICommandOptionDefinition } from "@brightside/imperative";
+import { ICommandOptionDefinition } from "@zowe/imperative";
 
 const MAX_LENGTH = 58;
 

--- a/src/cli/deploy/bundle/options/TargetState.option.ts
+++ b/src/cli/deploy/bundle/options/TargetState.option.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { ICommandOptionDefinition } from "@brightside/imperative";
+import { ICommandOptionDefinition } from "@zowe/imperative";
 
 /**
  * Imperative option for the "targetstate" parameter

--- a/src/cli/generate/Generate.definition.ts
+++ b/src/cli/generate/Generate.definition.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { ICommandDefinition } from "@brightside/imperative";
+import { ICommandDefinition } from "@zowe/imperative";
 import { GenerateBundleDefinition } from "./bundle/GenerateBundle.definition";
 /**
  * Imperative command to "generate" a Bundle, etc.

--- a/src/cli/generate/bundle/GenerateBundle.definition.ts
+++ b/src/cli/generate/bundle/GenerateBundle.definition.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { ICommandDefinition } from "@brightside/imperative";
+import { ICommandDefinition } from "@zowe/imperative";
 import { BundleidOption } from "./options/Bundleid.option";
 import { BundleversionOption } from "./options/Bundleversion.option";
 import { NodejsappOption } from "./options/Nodejsapp.option";

--- a/src/cli/generate/bundle/GenerateBundle.handler.ts
+++ b/src/cli/generate/bundle/GenerateBundle.handler.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { Logger, ICommandHandler, IHandlerParameters, ICommandArguments, ImperativeError } from "@brightside/imperative";
+import { Logger, ICommandHandler, IHandlerParameters, ICommandArguments, ImperativeError } from "@zowe/imperative";
 import { AutoBundler } from "../../../api/BundleContent/AutoBundler";
 import { BundleParentHandler } from "../../shared/BundleParent.handler";
 

--- a/src/cli/generate/bundle/options/Bundleid.option.ts
+++ b/src/cli/generate/bundle/options/Bundleid.option.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { ICommandOptionDefinition } from "@brightside/imperative";
+import { ICommandOptionDefinition } from "@zowe/imperative";
 
 /**
  * Imperative option for the "bundleid" parameter

--- a/src/cli/generate/bundle/options/Bundleversion.option.ts
+++ b/src/cli/generate/bundle/options/Bundleversion.option.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { ICommandOptionDefinition } from "@brightside/imperative";
+import { ICommandOptionDefinition } from "@zowe/imperative";
 
 /**
  * Imperative option for the "bundleversion" parameter

--- a/src/cli/generate/bundle/options/Merge.option.ts
+++ b/src/cli/generate/bundle/options/Merge.option.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { ICommandOptionDefinition } from "@brightside/imperative";
+import { ICommandOptionDefinition } from "@zowe/imperative";
 
 /**
  * Imperative option for the "merge" parameter

--- a/src/cli/generate/bundle/options/Nodejsapp.option.ts
+++ b/src/cli/generate/bundle/options/Nodejsapp.option.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { ICommandOptionDefinition } from "@brightside/imperative";
+import { ICommandOptionDefinition } from "@zowe/imperative";
 
 /**
  * Imperative option for the "nodejsapp" parameter

--- a/src/cli/generate/bundle/options/Overwrite.option.ts
+++ b/src/cli/generate/bundle/options/Overwrite.option.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { ICommandOptionDefinition } from "@brightside/imperative";
+import { ICommandOptionDefinition } from "@zowe/imperative";
 
 /**
  * Imperative option for the "overwrite" parameter

--- a/src/cli/generate/bundle/options/Port.option.ts
+++ b/src/cli/generate/bundle/options/Port.option.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { ICommandOptionDefinition } from "@brightside/imperative";
+import { ICommandOptionDefinition } from "@zowe/imperative";
 
 /**
  * Imperative option for the "bundleid" parameter

--- a/src/cli/generate/bundle/options/Startscript.option.ts
+++ b/src/cli/generate/bundle/options/Startscript.option.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { ICommandOptionDefinition } from "@brightside/imperative";
+import { ICommandOptionDefinition } from "@zowe/imperative";
 
 /**
  * Imperative option for the "startscript" parameter

--- a/src/cli/push/Push.definition.ts
+++ b/src/cli/push/Push.definition.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { ICommandDefinition } from "@brightside/imperative";
+import { ICommandDefinition } from "@zowe/imperative";
 import { PushBundleDefinition } from "./bundle/PushBundle.definition";
 /**
  * Imperative command to "push" a Bundle, etc.

--- a/src/cli/push/bundle/PushBundle.definition.ts
+++ b/src/cli/push/bundle/PushBundle.definition.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { ICommandDefinition } from "@brightside/imperative";
+import { ICommandDefinition } from "@zowe/imperative";
 import { NameOption } from "../../shared/Name.option";
 import { TargetdirOption } from "./options/Targetdir.option";
 import { CicsplexOption } from "../../shared/Cicsplex.option";

--- a/src/cli/push/bundle/PushBundle.handler.ts
+++ b/src/cli/push/bundle/PushBundle.handler.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { ICommandHandler, IHandlerParameters } from "@brightside/imperative";
+import { ICommandHandler, IHandlerParameters } from "@zowe/imperative";
 import { BundleParentHandler } from "../../shared/BundleParent.handler";
 import { BundlePusher } from "../../../api/BundlePush/BundlePusher";
 

--- a/src/cli/push/bundle/options/CmciOptions.ts
+++ b/src/cli/push/bundle/options/CmciOptions.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { ICommandOptionDefinition } from "@brightside/imperative";
+import { ICommandOptionDefinition } from "@zowe/imperative";
 
 /**
  * scmci command line options, derived from zowe-cics equivalents

--- a/src/cli/push/bundle/options/Overwrite.option.ts
+++ b/src/cli/push/bundle/options/Overwrite.option.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { ICommandOptionDefinition } from "@brightside/imperative";
+import { ICommandOptionDefinition } from "@zowe/imperative";
 
 /**
  * Imperative option for the "overwrite" parameter

--- a/src/cli/push/bundle/options/SshOptions.ts
+++ b/src/cli/push/bundle/options/SshOptions.ts
@@ -9,8 +9,8 @@
 *
 */
 
-import { ICommandOptionDefinition } from "@brightside/imperative";
-import { SshSession } from "@brightside/core";
+import { ICommandOptionDefinition } from "@zowe/imperative";
+import { SshSession } from "@zowe/cli";
 
 /**
  * ssh command line options, derived from zowe-cli equivalents

--- a/src/cli/push/bundle/options/Targetdir.option.ts
+++ b/src/cli/push/bundle/options/Targetdir.option.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { ICommandOptionDefinition } from "@brightside/imperative";
+import { ICommandOptionDefinition } from "@zowe/imperative";
 
 const MAX_LENGTH = 255;
 

--- a/src/cli/shared/BundleParent.handler.ts
+++ b/src/cli/shared/BundleParent.handler.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { Logger, ICommandHandler, IHandlerParameters, ICommandArguments, ImperativeError, Imperative } from "@brightside/imperative";
+import { Logger, ICommandHandler, IHandlerParameters, ICommandArguments, ImperativeError, Imperative } from "@zowe/imperative";
 
 /**
  * Generic Command handler for a CICS bundle action

--- a/src/cli/shared/Cicshlq.option.ts
+++ b/src/cli/shared/Cicshlq.option.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { ICommandOptionDefinition } from "@brightside/imperative";
+import { ICommandOptionDefinition } from "@zowe/imperative";
 
 const MAX_LENGTH = 35;
 

--- a/src/cli/shared/Cicsplex.option.ts
+++ b/src/cli/shared/Cicsplex.option.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { ICommandOptionDefinition } from "@brightside/imperative";
+import { ICommandOptionDefinition } from "@zowe/imperative";
 
 const MAX_LENGTH = 8;
 

--- a/src/cli/shared/Cpsmhlq.option.ts
+++ b/src/cli/shared/Cpsmhlq.option.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { ICommandOptionDefinition } from "@brightside/imperative";
+import { ICommandOptionDefinition } from "@zowe/imperative";
 
 const MAX_LENGTH = 35;
 

--- a/src/cli/shared/Csdgroup.option.ts
+++ b/src/cli/shared/Csdgroup.option.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { ICommandOptionDefinition } from "@brightside/imperative";
+import { ICommandOptionDefinition } from "@zowe/imperative";
 
 const MAX_LENGTH = 8;
 

--- a/src/cli/shared/Jobcard.option.ts
+++ b/src/cli/shared/Jobcard.option.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { ICommandOptionDefinition } from "@brightside/imperative";
+import { ICommandOptionDefinition } from "@zowe/imperative";
 
 /**
  * Imperative option for the "jobcard" parameter

--- a/src/cli/shared/Name.option.ts
+++ b/src/cli/shared/Name.option.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { ICommandOptionDefinition } from "@brightside/imperative";
+import { ICommandOptionDefinition } from "@zowe/imperative";
 
 const MAX_LENGTH = 8;
 

--- a/src/cli/shared/Resgroup.option.ts
+++ b/src/cli/shared/Resgroup.option.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { ICommandOptionDefinition } from "@brightside/imperative";
+import { ICommandOptionDefinition } from "@zowe/imperative";
 
 const MAX_LENGTH = 8;
 

--- a/src/cli/shared/Scope.option.ts
+++ b/src/cli/shared/Scope.option.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { ICommandOptionDefinition } from "@brightside/imperative";
+import { ICommandOptionDefinition } from "@zowe/imperative";
 
 const MAX_LENGTH = 8;
 

--- a/src/cli/shared/Timeout.option.ts
+++ b/src/cli/shared/Timeout.option.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { ICommandOptionDefinition } from "@brightside/imperative";
+import { ICommandOptionDefinition } from "@zowe/imperative";
 
 const MAX_VALUE = 1800;
 

--- a/src/cli/shared/Verbose.option.ts
+++ b/src/cli/shared/Verbose.option.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { ICommandOptionDefinition } from "@brightside/imperative";
+import { ICommandOptionDefinition } from "@zowe/imperative";
 
 /**
  * Imperative option for the "verbose" parameter

--- a/src/cli/shared/ZosmfOptions.ts
+++ b/src/cli/shared/ZosmfOptions.ts
@@ -9,8 +9,8 @@
 *
 */
 
-import { ICommandOptionDefinition } from "@brightside/imperative";
-import { ZosmfSession } from "@brightside/core";
+import { ICommandOptionDefinition } from "@zowe/imperative";
+import { ZosmfSession } from "@zowe/cli";
 
 /**
  * zosMF command line options, derived from zowe-cli equivalents

--- a/src/cli/undeploy/Undeploy.definition.ts
+++ b/src/cli/undeploy/Undeploy.definition.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { ICommandDefinition } from "@brightside/imperative";
+import { ICommandDefinition } from "@zowe/imperative";
 import { UndeployBundleDefinition } from "./bundle/UndeployBundle.definition";
 /**
  * Imperative command to "undeploy" a Bundle, etc.

--- a/src/cli/undeploy/bundle/UndeployBundle.definition.ts
+++ b/src/cli/undeploy/bundle/UndeployBundle.definition.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { ICommandDefinition } from "@brightside/imperative";
+import { ICommandDefinition } from "@zowe/imperative";
 import { NameOption } from "../../shared/Name.option";
 import { CicsplexOption } from "../../shared/Cicsplex.option";
 import { ScopeOption } from "../../shared/Scope.option";

--- a/src/cli/undeploy/bundle/UndeployBundle.handler.ts
+++ b/src/cli/undeploy/bundle/UndeployBundle.handler.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { Logger, ICommandHandler, IHandlerParameters, ICommandArguments, ImperativeError } from "@brightside/imperative";
+import { Logger, ICommandHandler, IHandlerParameters, ICommandArguments, ImperativeError } from "@zowe/imperative";
 import { BundleParentHandler } from "../../shared/BundleParent.handler";
 import { BundleDeployer } from "../../../api/BundleDeploy/BundleDeployer";
 

--- a/src/cli/undeploy/bundle/options/TargetState.option.ts
+++ b/src/cli/undeploy/bundle/options/TargetState.option.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { ICommandOptionDefinition } from "@brightside/imperative";
+import { ICommandOptionDefinition } from "@zowe/imperative";
 
 /**
  * Imperative option for the "targetstate" parameter

--- a/src/healthCheck.handler.ts
+++ b/src/healthCheck.handler.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import {ICommandHandler, IHandlerParameters, Logger} from "@brightside/imperative";
+import {ICommandHandler, IHandlerParameters, Logger} from "@zowe/imperative";
 
 export default class HealthCheckHandler implements ICommandHandler {
   public async process(params: IHandlerParameters): Promise<void> {

--- a/src/imperative.ts
+++ b/src/imperative.ts
@@ -10,7 +10,7 @@
 *
 */
 
-import {IImperativeConfig} from "@brightside/imperative";
+import {IImperativeConfig} from "@zowe/imperative";
 
 const MAX_LENGTH = 8;
 const MAX_HLQ_LENGTH = 35;

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,7 @@
 */
 
 
-import { Imperative } from "@brightside/imperative";
+import { Imperative } from "@zowe/imperative";
 // init imperative & parse the CLI input.
 Imperative.init().then(() => {
     Imperative.api.imperativeLogger.info("Imperative Initialized the cics-deploy CLI!");


### PR DESCRIPTION
resolve #297 

This is to check if our plugin is compatible with the zowe-cli's daily updates, which might have breakable changes
- Changed @brightside namespace to @zowe
- Jenkins build and test against `@zowe/cli@daily`
- It will be built and tested periodically in the same way as `master` and `dev` branches, but it will not deploy.
- Did NOT change any relevant documentation on purpose because this is for development purpose, not release purpose.
