### PR TITLE
Turn on _BPXK_AUTOCVT for npm

### DIFF
--- a/__tests__/api/BundlePush/BundlePusher.test.ts
+++ b/__tests__/api/BundlePush/BundlePusher.test.ts
@@ -935,9 +935,9 @@ describe("BundlePusher01", () => {
         });
 
         await runPushTestWithError("__tests__/__resources__/ExampleBundle01", false,
-              "A problem occurred attempting to run 'export PATH=\"$PATH:/usr/lpp/IBM/cnj/v8r0/IBM/node-latest-os390-s390x/bin\" " +
-              "&& npm install' in remote directory '/u/ThisDoesNotExist/12345678'. " +
-              "Problem is: The output from the remote command implied that an error occurred, return code 1.");
+        "A problem occurred attempting to run 'export PATH=\"$PATH:/usr/lpp/IBM/cnj/v8r0/IBM/node-latest-os390-s390x/bin\"" +
+        " && export _BPXK_AUTOCVT=ON && npm install' in remote directory '/u/ThisDoesNotExist/12345678'." +
+        " Problem is: The output from the remote command implied that an error occurred, return code 1.");
 
         expect(consoleText).toContain("Injected stdout error message");
         expect(zosMFSpy).toHaveBeenCalledTimes(1);
@@ -968,9 +968,9 @@ describe("BundlePusher01", () => {
         });
 
         await runPushTestWithError("__tests__/__resources__/ExampleBundle01", false,
-              "A problem occurred attempting to run 'export PATH=\"$PATH:/usr/lpp/IBM/cnj/v8r0/IBM/node-latest-os390-s390x/bin\" " +
-              "&& npm install' in remote directory '/u/ThisDoesNotExist/12345678'. " +
-              "Problem is: The output from the remote command implied that an error occurred, return code 1.");
+        "A problem occurred attempting to run 'export PATH=\"$PATH:/usr/lpp/IBM/cnj/v8r0/IBM/node-latest-os390-s390x/bin\"" +
+        " && export _BPXK_AUTOCVT=ON && npm install' in remote directory '/u/ThisDoesNotExist/12345678'." +
+        " Problem is: The output from the remote command implied that an error occurred, return code 1.");
 
         expect(consoleText).toContain("Injected FSUM7351 not found message");
         expect(zosMFSpy).toHaveBeenCalledTimes(1);
@@ -1001,9 +1001,9 @@ describe("BundlePusher01", () => {
         });
 
         await runPushTestWithError("__tests__/__resources__/ExampleBundle01", false,
-              "A problem occurred attempting to run 'export PATH=\"$PATH:/usr/lpp/IBM/cnj/v8r0/IBM/node-latest-os390-s390x/bin\" " +
-              "&& npm install' in remote directory '/u/ThisDoesNotExist/12345678'. " +
-              "Problem is: The output from the remote command implied that an error occurred, return code 1.");
+        "A problem occurred attempting to run 'export PATH=\"$PATH:/usr/lpp/IBM/cnj/v8r0/IBM/node-latest-os390-s390x/bin\"" +
+        " && export _BPXK_AUTOCVT=ON && npm install' in remote directory '/u/ThisDoesNotExist/12345678'." +
+        " Problem is: The output from the remote command implied that an error occurred, return code 1.");
 
         expect(consoleText).toContain("Injected npm ERR! Exit status 1 message");
         expect(zosMFSpy).toHaveBeenCalledTimes(1);
@@ -1079,6 +1079,16 @@ describe("BundlePusher01", () => {
         expect(uploadSpy).toHaveBeenCalledTimes(1);
         expect(readdirSpy).toHaveBeenCalledTimes(1);
         expect(lstatSpy).toHaveBeenCalledTimes(1);
+    });
+    it("should set up auto conversion before running npm install", async () => {
+        readdirSpy.mockImplementation((data: string) => {
+            return [ "package.json" ];
+          });
+        await runPushTest("__tests__/__resources__/ExampleBundle01", false, "PUSH operation completed");
+        expect(shellSpy).toBeCalledWith(expect.anything(),
+                                        expect.stringContaining("_BPXK_AUTOCVT=ON"),
+                                        expect.anything(),
+                                        expect.anything());
     });
     it("should run npm install for each package.json", async () => {
         const parms = getCommonParmsForPushTests();

--- a/src/api/BundlePush/BundlePusher.ts
+++ b/src/api/BundlePush/BundlePusher.ts
@@ -37,6 +37,7 @@ export class BundlePusher {
   private fs = require("fs");
   private progressBar: ITaskWithStatus;
   private defaultRemoteNodehomeCmd = "export PATH=\"$PATH:/usr/lpp/IBM/cnj/v8r0/IBM/node-latest-os390-s390x/bin\"";
+  private envSetupCommand = "export _BPXK_AUTOCVT=ON";
 
   /**
    * Constructor for a BundlePusher.
@@ -517,7 +518,9 @@ export class BundlePusher {
       this.updateStatus("Running 'npm install' in remote directory");
     }
 
-    await this.runSshCommandInRemoteDirectory(sshSession, remoteDirectory, this.defaultRemoteNodehomeCmd + " && npm install");
+    await this.runSshCommandInRemoteDirectory(sshSession,
+                                              remoteDirectory,
+                                              this.defaultRemoteNodehomeCmd + " && " + this.envSetupCommand + " && npm install");
   }
 
   private async runSingleNpmUninstall(sshSession: SshSession, remoteDirectory: string) {
@@ -530,7 +533,8 @@ export class BundlePusher {
 
     // uninstall each module individually
     await this.runSshCommandInRemoteDirectory(sshSession, remoteDirectory, this.defaultRemoteNodehomeCmd + " && " +
-          "if [ -d \"node_modules\" ] && [ \"$(ls node_modules)\" ]; then npm uninstall `ls -1 node_modules | tr '/\n' ' '`; fi");
+    this.envSetupCommand + " && " +
+    "if [ -d \"node_modules\" ] && [ \"$(ls node_modules)\" ]; then npm uninstall `ls -1 node_modules | tr '/\n' ' '`; fi");
   }
 
   private async runSshCommandInRemoteDirectory(sshSession: SshSession, directory: string, sshCommand: string) {


### PR DESCRIPTION
We've found with Node 8 _BPXK_AUTOCVT=ON is required otherwise you'll get a error like this:
```
npm 1: FSUM7332 syntax error: got ), expecting Newline
```
So we'll set it on before executing npm commands.  With this I can do a push with an empty `.profile`.