### PR TITLE
Ensure NOTICES.md is included in npm package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Changes should be placed under the following headings:
 ### Security
 - in case of vulnerabilities
 -->
+## [Release v1.0.3]
+
+### Added
+- Include NOTICES.md in npm package
 
 ## [Release v1.0.2]
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zowe-cli-cics-deploy-plugin",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "IBM CICS Bundle generation and deployment for Zowe CLI",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,15 @@
     "type": "git",
     "url": "https://github.com/IBM/zowe-cli-cics-deploy-plugin"
   },
+  "keywords": [
+    "cics",
+    "cli",
+    "mainframe",
+    "nodejs",
+    "zos",
+    "z/os",
+    "zowe"
+  ],
   "main": "lib/index.js",
   "files": [
     "lib",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "main": "lib/index.js",
   "files": [
-    "lib"
+    "lib",
+    "NOTICES.md"
   ],
   "bin": {
     "zowe-cli-cics-deploy": "./lib/main.js"


### PR DESCRIPTION
I noticed that NOTICES.md wasn't actually being included in our npm package as use `files` in package.json to explicitly include stuff. 
We'll need to push this out as 1.0.3.