### PR TITLE
Change zosMFSession return type to any to work around type mismatch error

### DIFF
--- a/src/api/BundleDeploy/BundleDeployer.ts
+++ b/src/api/BundleDeploy/BundleDeployer.ts
@@ -223,7 +223,7 @@ export class BundleDeployer {
     return jcl;
   }
 
-  private async createZosMFSession(): Promise<AbstractSession> {
+  private async createZosMFSession(): Promise<any> {
     // Create a zosMF session
     let zosmfProfile;
     try {

--- a/src/api/BundlePush/BundlePusher.ts
+++ b/src/api/BundlePush/BundlePusher.ts
@@ -282,7 +282,7 @@ export class BundlePusher {
     }
   }
 
-  private async createZosMFSession(zosmfProfile: IProfile): Promise<AbstractSession> {
+  private async createZosMFSession(zosmfProfile: IProfile): Promise<any> {
     try {
       return ZosmfSession.createBasicZosmfSession(zosmfProfile);
     }
@@ -324,7 +324,7 @@ export class BundlePusher {
     }
   }
 
-  private async validateBundleDirExistsAndIsEmpty(zosMFSession: AbstractSession) {
+  private async validateBundleDirExistsAndIsEmpty(zosMFSession: any) {
     try {
       this.updateStatus("Accessing contents of remote bundle directory");
 
@@ -445,7 +445,7 @@ export class BundlePusher {
     this.sshOutputText += data;
   }
 
-  private async makeBundleDir(zosMFSession: AbstractSession) {
+  private async makeBundleDir(zosMFSession: any) {
     if (this.params.arguments.verbose) {
       this.updateStatus("Making remote bundle directory '" + this.params.arguments.bundledir + "'");
     }
@@ -572,7 +572,7 @@ export class BundlePusher {
     }
   }
 
-  private async uploadBundle(zosMFSession: AbstractSession) {
+  private async uploadBundle(zosMFSession: any) {
     this.updateStatus("Uploading bundle contents to remote directory");
 
     const uploadOptions: IUploadOptions = { recursive: true };


### PR DESCRIPTION
This work around was suggested in zowe/imperative [issue](https://github.com/zowe/imperative/issues/285)
