### PR TITLE
Moves the doc site to use js.cookie

### DIFF
--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -27,7 +27,7 @@
 <!-- Added by C Harris on 1st May 2019 - used for code copying buttons -->
 <script src="https://cdn.jsdelivr.net/npm/clipboard@1/dist/clipboard.min.js"></script>
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-cookie/1.4.1/jquery.cookie.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/js-cookie@3.0.5/dist/js.cookie.min.js"></script>
 <script src="{{ "js/jquery.navgoco.min.js" }}"></script>
 
 


### PR DESCRIPTION
The previous jQuery-cookie that was being used has a CVE and unfortunately is no longer supported.  Moving the doc site to use js.cookie instead.