### PR TITLE
Archive the deploy plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> :warning: This repository has been archived and is no longer maintained.
+
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v1.4%20adopted-ff69b4.svg)](CODE_OF_CONDUCT)
 
 # IBM CICS Bundle Deployment Plugin for Zowe CLI

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -75,7 +75,7 @@
 </head>
 <body>
 <div class="deprecation-banner">
-    <p>⚠️ This product is no longer maintained and documentation here for reference only.</p>
+    <p>⚠️ This product is no longer maintained and the documentation here is for reference only.</p>
 </div>
 {% include topnav.html %}
 <!-- Page Content -->

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -74,6 +74,9 @@
 
 </head>
 <body>
+<div class="deprecation-banner">
+    <p>⚠️ This product is no longer maintained and documentation here for reference only.</p>
+</div>
 {% include topnav.html %}
 <!-- Page Content -->
 <div class="container">

--- a/docs/css/customstyles.css
+++ b/docs/css/customstyles.css
@@ -1225,3 +1225,22 @@ h4.panel-title {
     }
 }
 
+
+
+/* Deprecation Banner */
+.deprecation-banner {
+    background-color: #ffd700;
+    color: #000;
+    padding: 15px 20px;
+    text-align: center;
+    font-weight: bold;
+    font-size: 16px;
+    border-bottom: 3px solid #ccac00;
+    position: relative;
+    z-index: 1000;
+}
+
+.deprecation-banner p {
+    margin: 0;
+    padding: 0;
+}


### PR DESCRIPTION
Update the README.md with the archival information and add a banner to the top of the Docs site to say there is no support and its for reference only.